### PR TITLE
003 register/login fix

### DIFF
--- a/user/.gitignore
+++ b/user/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### Security ###
 properties.env
+JasyptConfigTest.java

--- a/user/src/main/java/com/zerobase/user/config/EncryptConfig.java
+++ b/user/src/main/java/com/zerobase/user/config/EncryptConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class EncryptConfig {
 
     @Bean
-    public AESUtil aesUtil() throws Exception {
+    public AESUtil aesUtil() throws Exception{
         return new AESUtil();
     }
 

--- a/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.zerobase.user.config;
+
+import com.zerobase.user.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final UserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
+
+    private final String TOKEN_HEADER = "Authorization";
+    private final String TOKEN_PREFIX = "Bearer ";
+
+    //본인의 토큰이 맞고 유효기간이 지나지 않았을 때
+    // 토큰이 없거나 유효하지 않은 경우 필터 체인으로 넘깁니다.
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        String jwtToken = resolveToken(request);
+        if (jwtToken != null && jwtUtil.validateToken(jwtToken, jwtUtil.extractUsername(jwtToken))) {
+            Authentication authentication = jwtUtil.getAuthentication(jwtToken);
+            log.info("Filtering request token Authentication: {}", authentication);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info(String.format("[%s] -> %s ",
+                    jwtUtil.extractUsername(jwtToken), request.getRequestURI())
+            );
+        }
+        log.info("Filtering request token: {}", jwtToken);
+        log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(TOKEN_HEADER);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}
+
+

--- a/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
+++ b/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
@@ -1,15 +1,28 @@
+
+
 package com.zerobase.user.config;
 
 import com.zerobase.user.service.CustomOAuth2UserService;
+import com.zerobase.user.service.SecurityMemberService;
+import com.zerobase.user.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import static org.springframework.security.config.Customizer.withDefaults;
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -17,27 +30,52 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Slf4j
 public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final SecurityMemberService securityMemberService;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(userDetailsService(), jwtUtil);
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(withDefaults())
-                .cors(withDefaults())
+        http
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers(
+                        .requestMatchers("/",
+                                "/login",
                                 "/login/**",
-                                "/register/**",
-                                "/csrf-token/**")
+                                "/users/register/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/csrf-token")
                         .permitAll()
-                        .requestMatchers("/user").hasRole("USER")
-                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/users/**").hasRole("USER")
                         .anyRequest().authenticated())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(
+                        jwtAuthenticationFilter(),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
                 .oauth2Login(oauth2Login ->
                         oauth2Login
                                 .userInfoEndpoint(userInfo -> userInfo
                                         .userService(customOAuth2UserService))
                                 .successHandler((request, response, authentication) -> {
                                     log.info("Login successful: {}", authentication.getPrincipal());
-                                    response.sendRedirect("/home");
+                                    List<GrantedAuthority> authorities =
+                                            new ArrayList<>(authentication.getAuthorities());
+                                    log.debug("authorities: {}", authorities);
+                                    String token =
+                                            jwtUtil.generateToken(authentication.getName(), authorities);
+                                    log.debug("token: {}", token);
+                                    response.setContentType("application/json");
+                                    response.setCharacterEncoding("UTF-8");
+                                    response.getWriter().write("{\"token\": \"" + token + "\"}");
                                 })
                                 .failureHandler((request, response, exception) -> {
                                     log.error("Login failed", exception);
@@ -51,5 +89,17 @@ public class SecurityConfig {
                         .invalidateHttpSession(true)
                         .deleteCookies("JSESSIONID"));
         return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return securityMemberService;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManagerBean(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authenticationManagerBuilder.userDetailsService(securityMemberService).passwordEncoder(passwordEncoder);
+        return authenticationManagerBuilder.build();
     }
 }

--- a/user/src/main/java/com/zerobase/user/controller/LoginController.java
+++ b/user/src/main/java/com/zerobase/user/controller/LoginController.java
@@ -1,23 +1,41 @@
 package com.zerobase.user.controller;
 
+import com.zerobase.user.dto.JwtResponse;
+import com.zerobase.user.dto.LoginForm;
 import com.zerobase.user.repository.MemberRepository;
+import com.zerobase.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class LoginController {
     private final MemberRepository memberRepository;
+    private final AuthService authService;
 
     //로그인 성공 후 반환
     @GetMapping("/home")
-    public ResponseEntity<Map<String, Object>> home(@AuthenticationPrincipal OAuth2User principal) {
+    public ResponseEntity<Map<String, Object>> home(
+            @AuthenticationPrincipal OAuth2User principal
+    ) {
         return ResponseEntity.ok(principal.getAttributes());
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtResponse> login(
+            @RequestBody LoginForm loginForm
+    ) throws Exception {
+        log.info("{} 님이 로그인하였습니다: ", loginForm.getUsername());
+        return ResponseEntity.ok(authService.authenticate(loginForm));
     }
 }

--- a/user/src/main/java/com/zerobase/user/controller/MemberController.java
+++ b/user/src/main/java/com/zerobase/user/controller/MemberController.java
@@ -31,8 +31,8 @@ public class MemberController {
     @GetMapping("/me")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<MemberDto> myInfo(@RequestHeader("Authorization") String token) throws Exception {
-        String loginId = jwtUtil.extractUsername(token.substring(7));
-        MemberDto myInfo = memberService.getMyInfo(loginId);
+        String username = jwtUtil.extractUsername(token.substring(7));
+        MemberDto myInfo = memberService.getMyInfo(username);
         return ResponseEntity.ok(myInfo);
     }
 
@@ -40,7 +40,7 @@ public class MemberController {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<MemberDto> updateMyInfo(
             @RequestHeader("Authorization") String token,
-            @RequestBody UpdateMemberForm updateMemberForm) throws Exception {
+            @RequestBody @Valid UpdateMemberForm updateMemberForm) throws Exception {
         String loginId = jwtUtil.extractUsername(token.substring(7));
         MemberDto updatedMember =
                 memberService.updateMyInfo(loginId, updateMemberForm);
@@ -49,7 +49,9 @@ public class MemberController {
 
     @DeleteMapping("/me")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Void> deleteAccount(@RequestHeader("Authorization") String token) throws Exception {
+    public ResponseEntity<Void> deleteAccount(
+            @RequestHeader("Authorization") String token
+    ) throws Exception {
         String loginId = jwtUtil.extractUsername(token.substring(7));
         memberService.deleteAccount(loginId);
         log.info(loginId + "님이 회원탈퇴하였습니다.");

--- a/user/src/main/java/com/zerobase/user/dto/JwtResponse.java
+++ b/user/src/main/java/com/zerobase/user/dto/JwtResponse.java
@@ -1,0 +1,14 @@
+package com.zerobase.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class JwtResponse {
+    private String token;
+}

--- a/user/src/main/java/com/zerobase/user/dto/LoginForm.java
+++ b/user/src/main/java/com/zerobase/user/dto/LoginForm.java
@@ -1,0 +1,11 @@
+package com.zerobase.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginForm {
+    private String username;
+    private String password;
+}

--- a/user/src/main/java/com/zerobase/user/dto/RegisterForm.java
+++ b/user/src/main/java/com/zerobase/user/dto/RegisterForm.java
@@ -21,7 +21,7 @@ public class RegisterForm {
     //15자 제한 - 영문+숫자 허용
     @NotBlank
     @Pattern(regexp = "^[a-zA-Z0-9]{6,20}$")
-    private String loginId;
+    private String username;
     //영문+숫자+특수문자 포함, 8~20자
     @NotBlank
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@#$%^&+=!]).{8,20}$")
@@ -53,7 +53,7 @@ public class RegisterForm {
     public MemberEntity toEntity(PasswordEncoder passwordEncoder, AESUtil aesUtil)
             throws Exception {
         return MemberEntity.builder()
-                .loginId(loginId)
+                .username(username)
                 .password(passwordEncoder.encode(password))
                 .email(email)
                 .phoneNumber(aesUtil.encrypt(phoneNumber))

--- a/user/src/main/java/com/zerobase/user/dto/UpdateMemberForm.java
+++ b/user/src/main/java/com/zerobase/user/dto/UpdateMemberForm.java
@@ -1,13 +1,20 @@
 package com.zerobase.user.dto;
 
 import com.zerobase.user.enums.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class UpdateMemberForm {
+    //2~12자
+    @NotBlank
+    @Size(min = 2, max = 12)
     private String nickName;
+    @NotBlank
+    @Size(min = 2, max = 12)
     private String name;
     private String job;
     private String interests;

--- a/user/src/main/java/com/zerobase/user/repository/AdminRepository.java
+++ b/user/src/main/java/com/zerobase/user/repository/AdminRepository.java
@@ -1,0 +1,14 @@
+package com.zerobase.user.repository;
+
+import com.zerobase.user.entity.AdminEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<AdminEntity, Long> {
+    Optional<AdminEntity> findByEmail(String email);
+
+    Optional<AdminEntity> findByUsername(String username);
+}

--- a/user/src/main/java/com/zerobase/user/service/AuthService.java
+++ b/user/src/main/java/com/zerobase/user/service/AuthService.java
@@ -1,45 +1,54 @@
-//package com.zerobase.user.service;
-//
-//import com.zerobase.user.dto.JwtResponse;
-//import com.zerobase.user.dto.LoginForm;
-//import com.zerobase.user.exception.CustomException;
-//import com.zerobase.user.exception.ErrorCode;
-//import com.zerobase.user.util.JwtUtil;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.security.authentication.AuthenticationManager;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.Authentication;
-//import org.springframework.security.core.AuthenticationException;
-//import org.springframework.security.core.GrantedAuthority;
-//import org.springframework.security.core.userdetails.UserDetails;
-//import org.springframework.stereotype.Service;
-//
-//import java.util.ArrayList;
-//import java.util.List;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class AuthService {
-//    private final AuthenticationManager authenticationManager;
-//    private final UserService userService;
-//    private final JwtUtil jwtUtil;
-//
-//    public JwtResponse authenticate(LoginForm loginForm) throws Exception {
-//        //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
-//        try {
-//            Authentication authentication = authenticationManager.authenticate(
-//                    new UsernamePasswordAuthenticationToken(loginForm.getLoginId(), loginForm.getPassword())
-//            );
-//        } catch (AuthenticationException e) {
-//            throw new CustomException(ErrorCode.INVALID_LOGIN);
-//        }
-//
-//        final UserDetails userDetails = userService.loadUserByUsername(loginForm.getLoginId());
-//        List<GrantedAuthority> authorities =
-//                new ArrayList<>(userDetails.getAuthorities());
-//        final String jwt =
-//                jwtUtil.generateToken(userDetails.getUsername(), authorities);
-//
-//        return new JwtResponse(jwt);
-//    }
-//}
+package com.zerobase.user.service;
+
+import com.zerobase.user.dto.JwtResponse;
+import com.zerobase.user.dto.LoginForm;
+import com.zerobase.user.exception.CustomException;
+import com.zerobase.user.exception.ErrorCode;
+import com.zerobase.user.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+    private final AuthenticationManager authenticationManager;
+    private final SecurityMemberService securityMemberService;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    public JwtResponse authenticate(LoginForm loginForm) throws Exception {
+        //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
+        try {
+            Authentication authenticate = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginForm.getUsername(),
+                            loginForm.getPassword()
+                    )
+            );
+            log.debug("Authentication successful");
+        } catch (AuthenticationException e) {
+            throw new CustomException(ErrorCode.INVALID_LOGIN);
+        }
+
+        final UserDetails userDetails = securityMemberService.loadUserByUsername(loginForm.getUsername());
+        log.debug("UserService.loadUserByUsername(loginForm.getUsername()) successful");
+        List<GrantedAuthority> authorities =
+                new ArrayList<>(userDetails.getAuthorities());
+        final String jwt =
+                jwtUtil.generateToken(userDetails.getUsername(), authorities);
+
+        return new JwtResponse(jwt);
+    }
+}

--- a/user/src/main/java/com/zerobase/user/service/MemberService.java
+++ b/user/src/main/java/com/zerobase/user/service/MemberService.java
@@ -9,12 +9,14 @@ import com.zerobase.user.exception.ErrorCode;
 import com.zerobase.user.repository.MemberRepository;
 import com.zerobase.user.util.AESUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -33,10 +35,11 @@ public class MemberService {
 
     //나의 정보 조회
     @Transactional
-    public MemberDto getMyInfo(String loginId) throws Exception {
-        MemberEntity memberEntity = memberRepository.findByUsername(loginId).orElseThrow(
+    public MemberDto getMyInfo(String username) throws Exception {
+        MemberEntity memberEntity = memberRepository.findByUsername(username).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND_USER)
         );
+        log.debug("memberEntity: {}", memberEntity);
         return memberEntity.toDto(aesUtil);
     }
 
@@ -64,8 +67,8 @@ public class MemberService {
                 () -> new CustomException(ErrorCode.NOT_FOUND_USER)
         );
         memberRepository.delete(memberEntity);
-
     }
+
     private void validateRegisterForm(RegisterForm registerForm) throws Exception {
         // 로그인 ID 중복 체크
         if(memberRepository.existsByUsername(registerForm.getUsername())) {

--- a/user/src/main/java/com/zerobase/user/service/SecurityAdminService.java
+++ b/user/src/main/java/com/zerobase/user/service/SecurityAdminService.java
@@ -1,0 +1,43 @@
+package com.zerobase.user.service;
+
+import com.zerobase.user.entity.AdminEntity;
+import com.zerobase.user.exception.CustomException;
+import com.zerobase.user.exception.ErrorCode;
+import com.zerobase.user.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityAdminService implements UserDetailsService {
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+            log.debug("Load user by username: {}", username);
+            AdminEntity adminEntity = adminRepository.findByUsername(username)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER)
+                    );
+
+            List<GrantedAuthority> authorities = adminEntity.getRoles().stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                    .collect(Collectors.toList());
+
+            return User.builder()
+                    .username(adminEntity.getUsername())
+                    .password(adminEntity.getPassword())
+                    .authorities(authorities)
+                    .build();
+    }
+}

--- a/user/src/main/java/com/zerobase/user/service/SecurityMemberService.java
+++ b/user/src/main/java/com/zerobase/user/service/SecurityMemberService.java
@@ -5,6 +5,7 @@ import com.zerobase.user.exception.CustomException;
 import com.zerobase.user.exception.ErrorCode;
 import com.zerobase.user.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -18,13 +19,15 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class UserService implements UserDetailsService {
+@Slf4j
+public class SecurityMemberService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username)
             throws UsernameNotFoundException {
-        MemberEntity memberEntity = memberRepository.findByLoginId(username)
+        log.debug("Load user by username: {}", username);
+        MemberEntity memberEntity = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER)
                 );
 
@@ -33,9 +36,10 @@ public class UserService implements UserDetailsService {
                 .collect(Collectors.toList());
 
         return User.builder()
-                .username(memberEntity.getLoginId())
+                .username(memberEntity.getUsername())
                 .password(memberEntity.getPassword())
                 .authorities(authorities)
                 .build();
     }
 }
+

--- a/user/src/main/java/com/zerobase/user/util/AESUtil.java
+++ b/user/src/main/java/com/zerobase/user/util/AESUtil.java
@@ -1,45 +1,82 @@
 package com.zerobase.user.util;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
 import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.Base64;
 
+@Slf4j
 public class AESUtil {
     private static final String ALGORITHM = "AES";
-    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
     private static final int KEY_SIZE = 256;
-    private static final int TAG_LENGTH_BIT = 128;
-    private static final int IV_LENGTH_BYTE = 12;
+    private static final int IV_LENGTH_BYTE = 16;
 
-    private final SecretKey secretKey;
+    @Value("${aes.password}")
+    private String password;
 
-    public AESUtil() throws Exception {
-        KeyGenerator keyGen = KeyGenerator.getInstance(ALGORITHM);
-        keyGen.init(KEY_SIZE);
-        this.secretKey = keyGen.generateKey();
+    @Value("${aes.salt}")
+    private String salt;
+
+    private SecretKey getSigningKey(String password, String salt)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
+        SecretKeyFactory factory =
+                SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec =
+                new PBEKeySpec(
+                        password.toCharArray(),
+                        salt.getBytes(),
+                        65536,
+                        KEY_SIZE
+                );
+        return new SecretKeySpec(
+                factory.generateSecret(spec).getEncoded(), ALGORITHM);
     }
 
-    public String encrypt(String data) throws Exception {
+    public String encrypt(String input) throws Exception {
+        SecretKey secretKey = getSigningKey(password, salt);
         Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-        byte[] iv = new byte[IV_LENGTH_BYTE];
-        GCMParameterSpec parameterSpec = new GCMParameterSpec(TAG_LENGTH_BIT, iv);
+        IvParameterSpec ivParameterSpec = generateIv();
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivParameterSpec);
+        byte[] cipherText = cipher.doFinal(input.getBytes());
 
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
-        byte[] encryptedData = cipher.doFinal(data.getBytes());
-
-        return Base64.getEncoder().encodeToString(encryptedData);
+        return  Base64.getEncoder().encodeToString(ivParameterSpec.getIV()) + "." +
+                Base64.getEncoder().encodeToString(cipherText);
     }
 
     public String decrypt(String encryptedData) throws Exception {
+        log.debug("encryptedData: {}", encryptedData);
+        byte[] decodedIv =
+                Base64.getDecoder().decode(
+                        encryptedData.substring(0, encryptedData.indexOf(".")));
+
+        String afterEncryptedData =
+                encryptedData.substring(encryptedData.indexOf(".") + 1);
+
+        SecretKey secretKey = getSigningKey(password, salt);
         Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(decodedIv);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivParameterSpec);
+
+        byte[] plainText = cipher.doFinal(Base64.getDecoder()
+                .decode(afterEncryptedData));
+
+        return new String(plainText);
+    }
+
+    public static IvParameterSpec generateIv() {
         byte[] iv = new byte[IV_LENGTH_BYTE];
-        GCMParameterSpec parameterSpec = new GCMParameterSpec(TAG_LENGTH_BIT, iv);
-
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, parameterSpec);
-        byte[] decodedData = Base64.getDecoder().decode(encryptedData);
-
-        return new String(cipher.doFinal(decodedData));
+        new SecureRandom().nextBytes(iv);
+        return new IvParameterSpec(iv);
     }
 }

--- a/user/src/main/java/com/zerobase/user/util/JwtUtil.java
+++ b/user/src/main/java/com/zerobase/user/util/JwtUtil.java
@@ -1,0 +1,109 @@
+package com.zerobase.user.util;
+
+import com.zerobase.user.enums.Role;
+import com.zerobase.user.service.SecurityAdminService;
+import com.zerobase.user.service.SecurityMemberService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtUtil {
+    @Value("${jwt.secret}")
+    private String secretStr;
+    private SecretKey SECRET_KEY;
+    private final SecurityAdminService securityAdminService;
+    private final SecurityMemberService securityMemberService;
+
+    @PostConstruct
+    public void init() {
+        byte[] decodedKey = Base64.getDecoder().decode(secretStr);
+        SECRET_KEY = new SecretKeySpec(decodedKey, 0, decodedKey.length, "HmacSHA256");
+    }
+
+    public String generateToken(String username, List<GrantedAuthority> authorities) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put(
+                "authorities",
+                authorities.stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.toList())
+        );
+        return createToken(claims, username);
+    }
+
+    private String createToken(Map<String, Object> claims, String username) {
+        return Jwts.builder()
+                .claims(claims)
+                .subject(username)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10 hours
+                .signWith(SECRET_KEY)
+                .compact();
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(SECRET_KEY)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractAllClaims(token).getExpiration().before(new Date());
+    }
+
+    public String extractUsername(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+
+
+    public List<Role> extractRoles(String token) {
+        List<String> roles = extractAllClaims(token).get("authorities", List.class);
+        return roles.stream().map(s -> Role.valueOf(s.substring("ROLE_".length())))
+                .collect(Collectors.toList());
+    }
+
+    public boolean validateToken(String token, String username) {
+        return (extractUsername(token).equals(username) && !isTokenExpired(token));
+    }
+
+    public Authentication getAuthentication(String jwt) {
+        log.info("Jwt : {}", jwt);
+
+        List<Role> roles = extractRoles(jwt);
+
+        UserDetails userDetails = null;
+        if (roles.contains(Role.ADMIN)) {
+            userDetails =
+                    this.securityAdminService.loadUserByUsername(
+                            this.extractUsername(jwt).trim()
+                    );
+        } else {
+            //usertype == USER
+            userDetails =
+                    this.securityMemberService.loadUserByUsername(
+                            this.extractUsername(jwt).trim()
+                    );
+        }
+
+        return new UsernamePasswordAuthenticationToken(userDetails,
+                "", userDetails.getAuthorities());
+    }
+}

--- a/user/src/main/resources/application-user.yml
+++ b/user/src/main/resources/application-user.yml
@@ -8,7 +8,7 @@ spring:
     password: ENC(PrfDuc2GADVS7iDBiQP171uUYe1fyfFC)
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -63,3 +63,13 @@ jasypt:
       bean: jasyptStringEncryptor
     password: ${SECRET_KEY}
 
+aes:
+  password: ENC(yGEk/YjqUhn34BwblUO5mQapkJ/2A+J3ux4JRuYFTiTEkXjy7D5hp5tZNATimMjOopJlQZaMmVk=)
+  salt: ENC(g/sMb9wlbW7WYrHl4AyKfz0lehFy5An7RIQXR2FpFs63onbNvMCrkQ==)
+
+jwt:
+  secret: ENC(nv2zQD07ToGj4ULUjnwOrWI+5wjIQo6GE4QZFbDiGSenOxv1G714D0DUZKznorOX85bUP+yTSl8=)
+
+logging:
+  level:
+    com.zerobase: DEBUG

--- a/user/src/test/java/com/zerobase/user/controller/MemberControllerTest.java
+++ b/user/src/test/java/com/zerobase/user/controller/MemberControllerTest.java
@@ -58,10 +58,10 @@ class MemberControllerTest {
                 .build();
 
         MemberEntity memberEntity = MemberEntity.builder()
-                .loginId(registerForm.getUsername())
+                .username(registerForm.getUsername())
                 .password(registerForm.getPassword())
                 .email(registerForm.getEmail())
-                .phoneNumber(registerForm.getPhoneNumber())
+                .phoneNumber(aesUtil.encrypt(registerForm.getPhoneNumber()))
                 .nickName(registerForm.getNickName())
                 .name(registerForm.getName())
                 .birth(registerForm.getBirth())
@@ -79,8 +79,7 @@ class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(registerForm))
                         .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.loginId").value(registerForm.getUsername()))
-                .andExpect(jsonPath("$.password").value(registerForm.getPassword()))
+                .andExpect(jsonPath("$.username").value(registerForm.getUsername()))
                 .andExpect(jsonPath("$.email").value(registerForm.getEmail()))
                 .andExpect(jsonPath("$.phoneNumber").value(registerForm.getPhoneNumber()))
                 .andExpect(jsonPath("$.nickName").value(registerForm.getNickName()))

--- a/user/src/test/java/com/zerobase/user/scratcher.http
+++ b/user/src/test/java/com/zerobase/user/scratcher.http
@@ -3,12 +3,12 @@ GET http://localhost:8080/csrf-token
 Content-Type: application/json
 
 ###회원가입
-POST http://localhost:8080/register
+POST http://localhost:8080/users/register
 Content-Type: application/json
-X-CSRF-TOKEN: eRiNWqUn1OmYtK4QGaluaC8hnZkhPwUc09-XFfupehYsdY4RTCy7aJNB4NC10pYjf4RaWk0WsPsUCGcxsbqkJpnMHHUdR7py
+X-CSRF-TOKEN: RL2BjwAYCWBH5Aq9RIhhM3DZ-Orh40ABsmrK7BfQkUmgZAMgJo_ivjd5PVZq0DmNc6VVVUfp1YuE2iQs11L71Sfn83uTVDJC
 
 {
-  "loginId": "testUser",
+  "username": "testUser",
   "password": "Test@1234",
   "email": "test@example.com",
   "phoneNumber": "01012345678",
@@ -19,3 +19,35 @@ X-CSRF-TOKEN: eRiNWqUn1OmYtK4QGaluaC8hnZkhPwUc09-XFfupehYsdY4RTCy7aJNB4NC10pYjf4
   "interests": "개발",
   "gender": "MALE"
 }
+
+### 자체 서비스 로그인
+POST http://localhost:8080/login
+Content-Type: application/json
+
+{
+  "username": "testUser",
+  "password": "Test@1234"
+}
+
+### 나의 정보 조회
+GET http://localhost:8080/users/me
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNjQ5ODQsImV4cCI6MTcyMDQwMDk4NH0.3x0MpxrY2QjoygxFsgfDLPGXER9B2EKeKJ7srvoHKeo
+
+### 정보 수정
+PUT http://localhost:8080/users/me
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNjQ5ODQsImV4cCI6MTcyMDQwMDk4NH0.3x0MpxrY2QjoygxFsgfDLPGXER9B2EKeKJ7srvoHKeo
+
+{
+  "nickName": "TestNick-update",
+  "name": "Test Name-update",
+  "job": "학생",
+  "interests": "백엔드 개발",
+  "gender": "MALE"
+}
+
+### 회원 탈퇴
+DELETE http://localhost:8080/users/me
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNTQ4OTksImV4cCI6MTcyMDM5MDg5OX0.r4TFfW9PHg1SgLojgb3EtTePEnudBLQyscU2xQW4w2A

--- a/user/src/test/java/com/zerobase/user/util/AESUtilTest.java
+++ b/user/src/test/java/com/zerobase/user/util/AESUtilTest.java
@@ -1,0 +1,42 @@
+package com.zerobase.user.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class AESUtilTest {
+
+    @Autowired
+    private AESUtil aesUtil;
+
+    public static String generateRandomKey() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] key = new byte[16];
+        secureRandom.nextBytes(key);
+        return Base64.getEncoder().encodeToString(key);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(generateRandomKey());
+    }
+
+    @Test
+    void encryptTest() throws Exception {
+        //given
+        String password = "123456";
+        String encrypted = aesUtil.encrypt(password);
+
+        //when
+        String decrypted = aesUtil.decrypt(encrypted);
+
+        //then
+        assertEquals("123456", decrypted);
+    }
+
+}


### PR DESCRIPTION
## 개요 (Summary)

<!-- 여기에 PR의 주요 변경 사항과 목적을 간단히 설명하세요 -->
- OAuth2에 jwt발행 적용
- 필드명 변경 (loginId -> username)
- AESUtil 알고리즘 변경 및 버그 수정
- JWT 토큰 발행 코드 수정(리팩토링 및 버그 수정)
- Spring Security UserDetailService 구현 클래스 수정(admin, member 둘로 나눔)
- spring boot starter validation 적용
## 변경 사항 (Changes)

<!-- 변경된 파일 및 주요 변경 사항을 기술하세요 -->
- 변경된 파일 1: AESUtil 클래스 수정(알고리즘 변경: AES/GCM/NoPadding -> AES/CBC/PKCS5Padding, 시크릿키, iv 일치시키도록 수정
- 변경된 파일 2: UpdateMemberForm spring-boot-start-validation 적용
- 변경된 파일 3: JwtAuthenticationFilter 로직 수정
- 변경된 파일 4: SecurityConfig 수정(formLogin 비활성화, oauth2.0 로그인 성공 시 JSON타입으로 반환하도록 수정)

## 테스트 결과 (Test Results)

<!-- 테스트 결과를 설명하세요 -->
- 테스트 1:  소셜 계정 로그인 후, jwt토큰 반환
- 테스트 2: 회원가입, 정보 조회, 수정, 삭제 테스트

## 체크리스트 (Checklist)

<!-- PR이 준비되었는지 확인하기 위한 체크리스트 -->
- [ v ] 코드가 의도한 대로 작동함
- [ v ] 새로운 테스트가 추가되었고, 기존 테스트가 통과함

## 참고 사항 (Additional Notes)
- Todo: 로그아웃 및 jwt토큰 무효화
