### PR TITLE
feat : 005-Logout : Logout 기능 구현

### DIFF
--- a/user/src/main/java/com/zerobase/user/UserApplication.java
+++ b/user/src/main/java/com/zerobase/user/UserApplication.java
@@ -6,12 +6,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EntityScan(basePackages = "com.zerobase")
 @EnableEncryptableProperties
 @PropertySource(name="EncryptedProperties", value = "classpath:application-user.yml")
+@EnableScheduling
 public class UserApplication {
 
     public static void main(String[] args) {

--- a/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
@@ -34,20 +34,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain chain
     ) throws ServletException, IOException {
-        String accessJtw = resolveToken(request, ACCESS_TOKEN_HEADER);
-        String refreshJtw = resolveToken(request, REFRESH_TOKEN_HEADER);
-        if (accessJtw != null &&
-                jwtUtil.validateToken(jwtUtil.extractUsername(accessJtw), accessJtw)) {
-            if (refreshJtw != null && !blackList.isListed(refreshJtw)) {
-                Authentication authentication = jwtUtil.getAuthentication(accessJtw);
+        String accessJwt = resolveToken(request, ACCESS_TOKEN_HEADER);
+        String refreshJwt = resolveToken(request, REFRESH_TOKEN_HEADER);
+        if (accessJwt != null &&
+                jwtUtil.validateToken(jwtUtil.extractUsername(accessJwt), accessJwt)) {
+            if (refreshJwt != null && !blackList.isListed(refreshJwt)) {
+                Authentication authentication = jwtUtil.getAuthentication(accessJwt);
                 log.info("Filtering request token Authentication: {}", authentication);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.info(String.format("[%s] -> %s ",
-                        jwtUtil.extractUsername(accessJtw), request.getRequestURI())
+                        jwtUtil.extractUsername(accessJwt), request.getRequestURI())
                 );
             }
         }
-        log.info("Filtering request token: {}", accessJtw);
+        log.info("Filtering request token: {}", accessJwt);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());
         chain.doFilter(request, response);
     }

--- a/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
+++ b/user/src/main/java/com/zerobase/user/config/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.zerobase.user.config;
 
+import com.zerobase.user.service.BlackList;
 import com.zerobase.user.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -20,33 +20,40 @@ import java.io.IOException;
 @Component
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final UserDetailsService userDetailsService;
     private final JwtUtil jwtUtil;
-
-    private final String TOKEN_HEADER = "Authorization";
+    private final BlackList blackList;
+    private final String ACCESS_TOKEN_HEADER = "Authorization";
+    private final String REFRESH_TOKEN_HEADER = "Refresh";
     private final String TOKEN_PREFIX = "Bearer ";
 
     //본인의 토큰이 맞고 유효기간이 지나지 않았을 때
     // 토큰이 없거나 유효하지 않은 경우 필터 체인으로 넘깁니다.
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String jwtToken = resolveToken(request);
-        if (jwtToken != null && jwtUtil.validateToken(jwtToken, jwtUtil.extractUsername(jwtToken))) {
-            Authentication authentication = jwtUtil.getAuthentication(jwtToken);
-            log.info("Filtering request token Authentication: {}", authentication);
-
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.info(String.format("[%s] -> %s ",
-                    jwtUtil.extractUsername(jwtToken), request.getRequestURI())
-            );
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+        String accessJtw = resolveToken(request, ACCESS_TOKEN_HEADER);
+        String refreshJtw = resolveToken(request, REFRESH_TOKEN_HEADER);
+        if (accessJtw != null &&
+                jwtUtil.validateToken(jwtUtil.extractUsername(accessJtw), accessJtw)) {
+            if (refreshJtw != null && !blackList.isListed(refreshJtw)) {
+                Authentication authentication = jwtUtil.getAuthentication(accessJtw);
+                log.info("Filtering request token Authentication: {}", authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info(String.format("[%s] -> %s ",
+                        jwtUtil.extractUsername(accessJtw), request.getRequestURI())
+                );
+            }
         }
-        log.info("Filtering request token: {}", jwtToken);
+        log.info("Filtering request token: {}", accessJtw);
         log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());
         chain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest request) {
-        String token = request.getHeader(TOKEN_HEADER);
+    private String resolveToken(HttpServletRequest request, String header) {
+        String token = request.getHeader(header);
 
         if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
             return token.substring(TOKEN_PREFIX.length());

--- a/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
+++ b/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
@@ -46,14 +46,13 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/",
-                                "/login",
-                                "/login/**",
+                                "users/login/**",
                                 "/users/register/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/csrf-token")
                         .permitAll()
-                        .requestMatchers("/users/**", "refresh/**").hasRole("USER")
+                        .requestMatchers("/users/**", "/users/refresh/**").hasRole("USER")
                         .requestMatchers("/logout").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated())
                 .csrf(AbstractHttpConfigurer::disable)

--- a/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
+++ b/user/src/main/java/com/zerobase/user/config/SecurityConfig.java
@@ -1,8 +1,8 @@
-
-
 package com.zerobase.user.config;
 
+import com.zerobase.user.service.BlackList;
 import com.zerobase.user.service.CustomOAuth2UserService;
+import com.zerobase.user.service.LogoutService;
 import com.zerobase.user.service.SecurityMemberService;
 import com.zerobase.user.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +33,12 @@ public class SecurityConfig {
     private final SecurityMemberService securityMemberService;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+    private final LogoutService logoutService;
+    private final BlackList blackList;
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(userDetailsService(), jwtUtil);
+        return new JwtAuthenticationFilter(jwtUtil, blackList);
     }
 
     @Bean
@@ -51,7 +53,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/csrf-token")
                         .permitAll()
-                        .requestMatchers("/users/**").hasRole("USER")
+                        .requestMatchers("/users/**", "refresh/**").hasRole("USER")
+                        .requestMatchers("/logout").hasAnyRole("USER", "ADMIN")
                         .anyRequest().authenticated())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session
@@ -70,24 +73,27 @@ public class SecurityConfig {
                                     List<GrantedAuthority> authorities =
                                             new ArrayList<>(authentication.getAuthorities());
                                     log.debug("authorities: {}", authorities);
-                                    String token =
+                                    String accessJwt =
                                             jwtUtil.generateToken(authentication.getName(), authorities);
-                                    log.debug("token: {}", token);
+                                    String refreshToken =
+                                            jwtUtil.generateRefreshToken(authentication.getName());
+
+                                    log.debug("token: {}", accessJwt);
+                                    log.debug("refreshToken: {}", refreshToken);
                                     response.setContentType("application/json");
                                     response.setCharacterEncoding("UTF-8");
-                                    response.getWriter().write("{\"token\": \"" + token + "\"}");
+                                    response.getWriter().write(
+                                            "{\"accessToken\": \""
+                                                    + accessJwt
+                                                    + "\", \"refreshToken\": \""
+                                                    + refreshToken + "\"}");
                                 })
                                 .failureHandler((request, response, exception) -> {
                                     log.error("Login failed", exception);
                                     response.sendRedirect("/error");
                                 }))
-                .logout(logout -> logout
-                        .logoutSuccessHandler((request, response, authentication) -> {
-                            log.info("Logout successful");
-                            response.sendRedirect("/login");
-                        })
-                        .invalidateHttpSession(true)
-                        .deleteCookies("JSESSIONID"));
+                .logout(AbstractHttpConfigurer::disable);
+
         return http.build();
     }
 

--- a/user/src/main/java/com/zerobase/user/controller/LoginController.java
+++ b/user/src/main/java/com/zerobase/user/controller/LoginController.java
@@ -27,7 +27,7 @@ public class LoginController {
         return ResponseEntity.ok(principal.getAttributes());
     }
 
-    @PostMapping("/login")
+    @PostMapping("users/login")
     public ResponseEntity<JwtResponse> login(
             @RequestBody LoginForm loginForm
     ) throws Exception {
@@ -35,7 +35,7 @@ public class LoginController {
         return ResponseEntity.ok(authService.authenticate(loginForm));
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/users/refresh")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<JwtResponse> refreshToken(
             @RequestHeader(name = "Authorization") String accessToken,

--- a/user/src/main/java/com/zerobase/user/controller/LoginController.java
+++ b/user/src/main/java/com/zerobase/user/controller/LoginController.java
@@ -2,17 +2,14 @@ package com.zerobase.user.controller;
 
 import com.zerobase.user.dto.JwtResponse;
 import com.zerobase.user.dto.LoginForm;
-import com.zerobase.user.repository.MemberRepository;
 import com.zerobase.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -20,7 +17,6 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class LoginController {
-    private final MemberRepository memberRepository;
     private final AuthService authService;
 
     //로그인 성공 후 반환
@@ -38,4 +34,16 @@ public class LoginController {
         log.info("{} 님이 로그인하였습니다: ", loginForm.getUsername());
         return ResponseEntity.ok(authService.authenticate(loginForm));
     }
+
+    @PostMapping("/refresh")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<JwtResponse> refreshToken(
+            @RequestHeader(name = "Authorization") String accessToken,
+            @RequestHeader(name = "Refresh") String refreshToken
+    ) throws Exception {
+        refreshToken = refreshToken.replace("Bearer ", "");
+        accessToken = accessToken.replace("Bearer ", "");
+        return ResponseEntity.ok(authService.refreshToken(accessToken, refreshToken));
+    }
+
 }

--- a/user/src/main/java/com/zerobase/user/controller/LogoutController.java
+++ b/user/src/main/java/com/zerobase/user/controller/LogoutController.java
@@ -1,0 +1,37 @@
+package com.zerobase.user.controller;
+
+import com.zerobase.user.service.LogoutService;
+import com.zerobase.user.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutController {
+    private final LogoutService logoutService;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/logout")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ResponseEntity<Void> logout(
+            @RequestHeader(name = "Authorization") String accessToken,
+            @RequestHeader(name = "Refresh") String refreshToken,
+            HttpServletRequest request
+    ) {
+        log.debug("logout controller start!!!!");
+        log.debug("accessToken: {}", accessToken);
+        log.debug("request access token == accesstoken: {}", request.getHeader("Authorization").equals(accessToken));
+        log.debug("refreshToken: {}", refreshToken);
+        log.debug("request refresh token == refreshtoken: {}", request.getHeader("Refresh").equals(refreshToken));
+
+        logoutService.logout(request, null, null);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/user/src/main/java/com/zerobase/user/dto/JwtResponse.java
+++ b/user/src/main/java/com/zerobase/user/dto/JwtResponse.java
@@ -10,5 +10,6 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class JwtResponse {
-    private String token;
+    private String accessJwt;
+    private String refreshJwt;
 }

--- a/user/src/main/java/com/zerobase/user/exception/CustomException.java
+++ b/user/src/main/java/com/zerobase/user/exception/CustomException.java
@@ -1,5 +1,8 @@
 package com.zerobase.user.exception;
 
+import lombok.Getter;
+
+@Getter
 public class CustomException extends RuntimeException {
     private ErrorCode errorCode;
     public CustomException(ErrorCode errorCode) {

--- a/user/src/main/java/com/zerobase/user/exception/ErrorCode.java
+++ b/user/src/main/java/com/zerobase/user/exception/ErrorCode.java
@@ -6,13 +6,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 만료되었거나 사용자가 유효하지 않습니다."),
     UNABLE_TO_GET_TOKEN(HttpStatus.BAD_REQUEST, "발급된 토큰이 없습니다."),
     CHECK_HEADER_BEARER(HttpStatus.BAD_REQUEST, "토큰의 접두사에 'Bearer '가 있는지 확인하세요."),
     INVALID_LOGIN(HttpStatus.BAD_REQUEST, "잘못된 아이디 또는 비밀번호입니다."),
     ALREADY_EXIST_LOGINID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "해당 이메일로 가입한 내역이 있습니다."),
-    ALREADY_EXIST_PHONE(HttpStatus.BAD_REQUEST, "해당 전화번호로 가입한 내역이 있습니다.");
+    ALREADY_EXIST_PHONE(HttpStatus.BAD_REQUEST, "해당 전화번호로 가입한 내역이 있습니다."),
+    NO_VALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효한 리프레시 토큰이 없습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/user/src/main/java/com/zerobase/user/service/AuthService.java
+++ b/user/src/main/java/com/zerobase/user/service/AuthService.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -26,7 +25,6 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final SecurityMemberService securityMemberService;
     private final JwtUtil jwtUtil;
-    private final PasswordEncoder passwordEncoder;
 
     public JwtResponse authenticate(LoginForm loginForm) throws Exception {
         //loginId와 비밀번호 일치여부 확인 (불일치 시 예외 발생)
@@ -46,9 +44,27 @@ public class AuthService {
         log.debug("UserService.loadUserByUsername(loginForm.getUsername()) successful");
         List<GrantedAuthority> authorities =
                 new ArrayList<>(userDetails.getAuthorities());
-        final String jwt =
+        final String accessJwt =
                 jwtUtil.generateToken(userDetails.getUsername(), authorities);
+        final String refreshJwt = jwtUtil.generateRefreshToken(userDetails.getUsername());
 
-        return new JwtResponse(jwt);
+        return new JwtResponse(accessJwt, refreshJwt);
+    }
+
+    public JwtResponse refreshToken(String accessToken, String refreshToken) throws Exception {
+        String username = jwtUtil.extractUsername(accessToken);
+        if (!jwtUtil.validateToken(username,
+                refreshToken)
+        ) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        UserDetails userDetails = securityMemberService.loadUserByUsername(username);
+        List<GrantedAuthority> authorities = new ArrayList<>(userDetails.getAuthorities());
+        String newAccessToken = jwtUtil.generateToken(username, authorities);
+//        log.info("refresh access token issued at: {}", jwtUtil.extractAllClaims(refreshToken).getIssuedAt());
+//        log.info("refresh access token expiration: {}", jwtUtil.extractAllClaims(refreshToken).getExpiration());
+//        log.info("newAccessToken issued at: {}", jwtUtil.extractAllClaims(newAccessToken).getIssuedAt());
+//        log.info("newAccessToken Expiration: {}", jwtUtil.extractAllClaims(newAccessToken).getExpiration());
+        return new JwtResponse(newAccessToken, refreshToken);
     }
 }

--- a/user/src/main/java/com/zerobase/user/service/BlackList.java
+++ b/user/src/main/java/com/zerobase/user/service/BlackList.java
@@ -1,0 +1,51 @@
+package com.zerobase.user.service;
+
+import com.zerobase.user.exception.CustomException;
+import com.zerobase.user.exception.ErrorCode;
+import com.zerobase.user.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BlackList {
+    private final JwtUtil jwtUtil;
+
+    private final Map<String, Date> blacklist = new ConcurrentHashMap<>();
+
+    public void add(String refreshToken) {
+        log.debug("logoutService: refreshToken: {}", refreshToken);
+        Date expiry = jwtUtil.extractAllClaims(refreshToken)
+                .getExpiration();
+        // 토큰을 블랙리스트에 추가
+        blacklist.put(refreshToken, expiry);
+    }
+
+    // 토큰이 블랙리스트에 있는지 확인
+    public boolean isListed(String token) {
+        if (token == null) {
+            throw new CustomException(ErrorCode.NO_VALID_REFRESH_TOKEN);
+        }
+        if (blacklist.isEmpty()) {
+            return false;
+        }
+
+        return blacklist.containsKey(token) &&
+                blacklist.get(token).after(new Date());
+    }
+    // 주기적으로 블랙리스트에서 만료된 토큰 제거
+    @Scheduled(fixedRate = 60000) //1분
+    public void removeExpiredTokens() {
+        blacklist.entrySet().removeIf(entry -> entry.getValue().before(new Date()));
+    }
+
+
+
+}

--- a/user/src/main/java/com/zerobase/user/service/LogoutService.java
+++ b/user/src/main/java/com/zerobase/user/service/LogoutService.java
@@ -1,0 +1,32 @@
+package com.zerobase.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LogoutService implements LogoutHandler {
+    private final BlackList blackList;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        request.getSession().invalidate();
+        SecurityContextHolder.clearContext();
+        String refreshToken = request
+                .getHeader("Refresh");
+        if (refreshToken != null && refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring("Bearer ".length());
+            blackList.add(refreshToken);
+            log.info("Refresh token added to blacklist: {}", refreshToken);
+        } else {
+            log.warn("No valid refresh token found in the request headers.");
+        }
+    }
+}

--- a/user/src/test/java/com/zerobase/user/scratcher.http
+++ b/user/src/test/java/com/zerobase/user/scratcher.http
@@ -32,16 +32,17 @@ Content-Type: application/json
 ### 나의 정보 조회
 GET http://localhost:8080/users/me
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNjQ5ODQsImV4cCI6MTcyMDQwMDk4NH0.3x0MpxrY2QjoygxFsgfDLPGXER9B2EKeKJ7srvoHKeo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjA1MTM1MDMsImV4cCI6MTcyMDUxNDQwM30.ndsVHD55qWTvJCLMlb2dEuTQOHI4kTUvYdUfwqH84v0
+Refresh: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6W10sInN1YiI6InRlc3RVc2VyIiwiaWF0IjoxNzIwNTEzNTAzLCJleHAiOjE3MjExMTgzMDN9.6nrzQFZz-CmhZxErnGKCnBiUytBGkVJbx2YgMnuId3M
 
 ### 정보 수정
 PUT http://localhost:8080/users/me
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNjQ5ODQsImV4cCI6MTcyMDQwMDk4NH0.3x0MpxrY2QjoygxFsgfDLPGXER9B2EKeKJ7srvoHKeo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjA1MDkzMjEsImV4cCI6MTcyMDUxMDIyMX0.XOt_gLGBwE4b8eVbKGerJHXKlieJ_T567PDwcm2CxOk
 
 {
-  "nickName": "TestNick-update",
-  "name": "Test Name-update",
+  "nickName": "Test-update",
+  "name": "Test-update",
   "job": "학생",
   "interests": "백엔드 개발",
   "gender": "MALE"
@@ -51,3 +52,16 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiX
 DELETE http://localhost:8080/users/me
 Content-Type: application/json
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjAzNTQ4OTksImV4cCI6MTcyMDM5MDg5OX0.r4TFfW9PHg1SgLojgb3EtTePEnudBLQyscU2xQW4w2A
+
+### 토큰 재발급
+POST http://localhost:8080/refresh
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjA1ODk2ODMsImV4cCI6MTcyMDU5MTQ4M30.fUXa_XrqWPiRuM5b-xTxgJlx5aC0441ffbS7jNgffK4
+Refresh: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6W10sInN1YiI6InRlc3RVc2VyIiwiaWF0IjoxNzIwNTg5NjgzLCJleHAiOjE3MjExOTQ0ODN9.GmoGHK8iXexHluxEbyhvWuVrTKfKxGTliP46WyS9kjc
+
+
+### 로그아웃
+POST http://localhost:8080/logout
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjA1OTE1NjgsImV4cCI6MTcyMDU5MzM2OH0.Y_jxvuMZbk6YUhQtkyiQtgobuqbjiDPn3-X5DPmABcI
+Refresh: Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6W10sInN1YiI6InRlc3RVc2VyIiwiaWF0IjoxNzIwNTkxNTY4LCJleHAiOjE3MjExOTYzNjh9.PgnWNKSwKfJyA7rU94EHQTPF6uyvWr23Gr3MGZX1liE
+

--- a/user/src/test/java/com/zerobase/user/service/AuthServiceTest.java
+++ b/user/src/test/java/com/zerobase/user/service/AuthServiceTest.java
@@ -1,0 +1,152 @@
+package com.zerobase.user.service;
+
+import com.zerobase.user.dto.JwtResponse;
+import com.zerobase.user.dto.LoginForm;
+import com.zerobase.user.exception.CustomException;
+import com.zerobase.user.exception.ErrorCode;
+import com.zerobase.user.util.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private SecurityMemberService securityMemberService;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void authenticate_success() throws Exception {
+        // given
+        String username = "testUser";
+        String password = "password";
+        LoginForm loginForm = new LoginForm();
+        loginForm.setUsername(username);
+        loginForm.setPassword(password);
+
+        UserDetails userDetails = mock(UserDetails.class);
+        List<GrantedAuthority> authorities =
+                new ArrayList<>(userDetails.getAuthorities());
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationManager
+                .authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(securityMemberService.loadUserByUsername(username))
+                .thenReturn(userDetails);
+        when(userDetails.getUsername()).thenReturn(username);
+        when(jwtUtil.generateToken(username, authorities)).thenReturn("accessJwt");
+        when(jwtUtil.generateRefreshToken(username)).thenReturn("refreshJwt");
+
+        // when
+        JwtResponse result = authService.authenticate(loginForm);
+
+        // then
+        assertEquals("accessJwt", result.getAccessJwt());
+        assertEquals("refreshJwt", result.getRefreshJwt());
+    }
+
+    @Test
+    public void testAuthenticateFailure() {
+        // given
+        String username = "testUser";
+        String password = "password";
+        LoginForm loginForm = new LoginForm();
+        loginForm.setUsername(username);
+        loginForm.setPassword(password);
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenThrow(new AuthenticationException("Iznvalid login credentials") {});
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            authService.authenticate(loginForm);
+        });
+
+        // then
+        assertEquals(ErrorCode.INVALID_LOGIN, exception.getErrorCode());
+        assertEquals("잘못된 아이디 또는 비밀번호입니다.", exception.getMessage());
+        verify(authenticationManager, times(1))
+                .authenticate(any(UsernamePasswordAuthenticationToken.class));
+        verify(securityMemberService, never()).loadUserByUsername(anyString());
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+        verify(jwtUtil, never()).generateRefreshToken(anyString());
+    }
+
+    @Test
+    public void refreshToken_Success() throws Exception {
+        // given
+        String accessToken = "validAccessToken";
+        String refreshToken = "validRefreshToken";
+        String username = "testUser";
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        UserDetails userDetails = mock(UserDetails.class);
+
+        when(jwtUtil.extractUsername(accessToken)).thenReturn(username);
+        when(jwtUtil.validateToken(username, refreshToken)).thenReturn(true);
+        when(securityMemberService.loadUserByUsername(username)).thenReturn(userDetails);
+        when(jwtUtil.generateToken(username, authorities)).thenReturn("newAccessToken");
+        // when
+        JwtResponse jwtResponse = authService.refreshToken(accessToken, refreshToken);
+
+        // then
+        assertNotNull(jwtResponse);
+        assertEquals("newAccessToken", jwtResponse.getAccessJwt());
+        assertEquals(refreshToken, jwtResponse.getRefreshJwt());
+
+        verify(jwtUtil, times(1)).extractUsername(accessToken);
+        verify(jwtUtil, times(1)).validateToken(username, refreshToken);
+        verify(securityMemberService, times(1)).loadUserByUsername(username);
+        verify(jwtUtil, times(1)).generateToken(username, authorities);
+    }
+
+
+    @Test
+    public void testRefreshTokenFailure() {
+        // given
+        String accessToken = "validAccessToken";
+        String refreshToken = "invalidRefreshToken";
+        String username = "testUser";
+
+        when(jwtUtil.extractUsername(accessToken)).thenReturn(username);
+        when(jwtUtil.validateToken(username, refreshToken)).thenReturn(false);
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            authService.refreshToken(accessToken, refreshToken);
+        });
+
+        // then
+        assertEquals(ErrorCode.INVALID_TOKEN, exception.getErrorCode());
+
+        verify(jwtUtil, times(1)).extractUsername(accessToken);
+        verify(jwtUtil, times(1)).validateToken(username, refreshToken);
+        verify(securityMemberService, never()).loadUserByUsername(anyString());
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+    }
+}

--- a/user/src/test/java/com/zerobase/user/service/BlackListTest.java
+++ b/user/src/test/java/com/zerobase/user/service/BlackListTest.java
@@ -1,0 +1,136 @@
+package com.zerobase.user.service;
+
+import com.zerobase.user.exception.CustomException;
+import com.zerobase.user.exception.ErrorCode;
+import com.zerobase.user.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlackListTest {
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private BlackList blackList;
+
+    @Test
+    public void testAdd() {
+        // given
+        String refreshToken = "validRefreshToken";
+        String refreshToken2 = "validRefreshToken2";
+        Date expiryDate = new Date(System.currentTimeMillis() + 10000); // 10 초
+        Claims claims = mock(Claims.class);
+        Claims claims2 = mock(Claims.class);
+        when(jwtUtil.extractAllClaims(refreshToken)).thenReturn(claims);
+        when(jwtUtil.extractAllClaims(refreshToken2)).thenReturn(claims2);
+        when(claims.getExpiration()).thenReturn(expiryDate);
+        when(claims2.getExpiration()).thenReturn(expiryDate);
+
+        // when
+        blackList.add(refreshToken);
+        blackList.add(refreshToken2);
+
+        // then
+        assertTrue(blackList.isListed(refreshToken));
+        assertTrue(blackList.isListed(refreshToken2));
+        verify(jwtUtil, times(1)).extractAllClaims(refreshToken);
+        verify(claims, times(1)).getExpiration();
+    }
+
+    @Test
+    void isListed_true() {
+        // given
+        String refreshToken = "validRefreshToken";
+        Date expiryDate = new Date(System.currentTimeMillis() + 10000); // 10 seconds later
+        Claims claims = mock(Claims.class);
+        when(jwtUtil.extractAllClaims(refreshToken)).thenReturn(claims);
+        when(claims.getExpiration()).thenReturn(expiryDate);
+        blackList.add(refreshToken);
+
+        // when
+        boolean result = blackList.isListed(refreshToken);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    public void isListed_false() {
+        // given
+        String refreshToken = "nonListedToken";
+
+        // when
+        boolean result = blackList.isListed(refreshToken);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    public void isListed_null() {
+        // when
+        CustomException exception =
+                assertThrows(
+                        CustomException.class, () -> {
+            blackList.isListed(null);
+        });
+
+        // then
+        assertEquals(ErrorCode.NO_VALID_REFRESH_TOKEN, exception.getErrorCode());
+    }
+
+    @Test
+    public void removeExpiredTokens_success() {
+        // given
+        String refreshToken = "expiredRefreshToken";
+        Date expiryDate = new Date(System.currentTimeMillis() - 10000); // 10 seconds ago
+        Claims claims = mock(Claims.class);
+        when(jwtUtil.extractAllClaims(refreshToken)).thenReturn(claims);
+        when(claims.getExpiration()).thenReturn(expiryDate);
+        blackList.add(refreshToken);
+
+        // when
+        blackList.removeExpiredTokens();
+
+        // then
+        assertFalse(blackList.isListed(refreshToken));
+    }
+
+    @Test
+    public void removeExpiredTokens_withTimeSleep() throws InterruptedException {
+        // given
+        String refreshToken = "expiredRefreshToken";
+        String refreshToken2 = "validRefreshToken";
+        Date expiredDate = new Date(System.currentTimeMillis() - 10000); // 10 seconds ago
+        Date validDate = new Date(System.currentTimeMillis() + 10000); // 10 seconds later
+        Claims expiredClaims = mock(Claims.class);
+        Claims validClaims = mock(Claims.class);
+
+        when(jwtUtil.extractAllClaims(refreshToken)).thenReturn(expiredClaims);
+        when(jwtUtil.extractAllClaims(refreshToken2)).thenReturn(validClaims);
+        when(expiredClaims.getExpiration()).thenReturn(expiredDate);
+        when(validClaims.getExpiration()).thenReturn(validDate);
+
+        blackList.add(refreshToken);
+        blackList.add(refreshToken2);
+
+        Thread.sleep(1000);
+
+        // when
+        blackList.removeExpiredTokens();
+
+        // then
+        assertFalse(blackList.isListed(refreshToken));
+        assertTrue(blackList.isListed(refreshToken2));
+    }
+}

--- a/user/src/test/java/com/zerobase/user/service/LogoutServiceTest.java
+++ b/user/src/test/java/com/zerobase/user/service/LogoutServiceTest.java
@@ -1,0 +1,53 @@
+package com.zerobase.user.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+    @Mock
+    private BlackList blackList;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private LogoutService logoutService;
+
+    @BeforeEach
+    public void setUp() {
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    }
+
+    @Test
+    void logout_success() {
+        // given
+        when(request.getHeader("Refresh")).thenReturn("Bearer validRefreshToken");
+
+        // when
+        logoutService.logout(request, response, authentication);
+
+        // then
+        verify(request, times(1)).getSession();
+        verify(request, times(1)).getHeader("Refresh");
+        verify(blackList, times(1)).add("validRefreshToken");
+        verify(authentication, never()).setAuthenticated(false);
+    }
+}

--- a/user/src/test/java/com/zerobase/user/util/JwtUtilTest.java
+++ b/user/src/test/java/com/zerobase/user/util/JwtUtilTest.java
@@ -1,0 +1,29 @@
+package com.zerobase.user.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+class JwtUtilTest {
+
+    public static void main(String[] args) {
+        String token = "eyJhbGciOiJIUzI1NiJ9.eyJhdXRob3JpdGllcyI6WyJST0xFX1VTRVIiXSwic3ViIjoidGVzdFVzZXIiLCJpYXQiOjE3MjA1MTUzMDYsImV4cCI6MTcyMDUxNjIwNn0.DD-XiP3GN4b_dd1jWa7-VNf-l77bsecjEVtr8iVCbZc";
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length == 3) {
+                Base64.Decoder decoder = Base64.getUrlDecoder();
+                String header = new String(decoder.decode(parts[0]), StandardCharsets.UTF_8);
+                String payload = new String(decoder.decode(parts[1]), StandardCharsets.UTF_8);
+                String signature = parts[2];
+
+                System.out.println("Header: " + header);
+                System.out.println("Payload: " + payload);
+                System.out.println("signature: " + signature);
+            } else {
+                System.out.println("Invalid JWT token format.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION

## 개요 (Summary)

<!-- 여기에 PR의 주요 변경 사항과 목적을 간단히 설명하세요 -->
- 변경된 주요 내용 1 : jwt 토큰을 액세스 토큰과 리프레시 토큰으로 관리하도록 refresh api 추가
- 변경된 주요 내용 2 : 리프레시 토큰을 블랙리스트에 저장하는 방식으로 로그아웃 기능 구현

## 변경 사항 (Changes)

<!-- 변경된 파일 및 주요 변경 사항을 기술하세요 -->
- LoginController : refresh token을 사용하여 access token 갱신하는 api 추가
- AuthService : refreshToken() 메서드 추가. refresh token 으로부터 access 토큰 갱싱
- LogoutController : LogoutController 생성 후 logout api 추가
- LogoutService : 블랙리스트에 refresh token 추가
  - 블랙리스트 추가 메서드
  - 블랙리스트에 해당 refresh token 존재 여부 확인 메서드
  - 1분 단위로 기한이 만료된 refresh token 삭제 메서드 
- JwtAuthenticationFilter 수정 : 필터링 하는 refresh token이 블랙리스트에 있는지 확인하는 로직 추가
- SecurityConfig 수정 : Spring Security logout 기능 비활성화

## 테스트 결과 (Test Results)

<!-- 테스트 결과를 설명하세요 -->
- refresh token 테스트 성공/실패 케이스 테스트
- logoutService 테스트 성공/실패 케이스 테스트
- blakcList 테스트 성공/실패 케이스 테스트

## 체크리스트 (Checklist)

<!-- PR이 준비되었는지 확인하기 위한 체크리스트 -->
- [ v ] 코드가 의도한 대로 작동함
- [ v ] 새로운 테스트가 추가되었고, 기존 테스트가 통과함
- [ v ] 변경 사항이 적절하게 설명됨

