### PR TITLE
008 challenge create/update

### DIFF
--- a/api-gateway/src/main/java/com/zerobase/apigateway/filter/AuthorizationFilter.java
+++ b/api-gateway/src/main/java/com/zerobase/apigateway/filter/AuthorizationFilter.java
@@ -66,7 +66,8 @@ public class AuthorizationFilter implements GlobalFilter, Ordered {
         Authentication authentication = jwtUtil.getAuthentication(token);
         return chain.filter(exchange)
                 .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
-                .doOnSuccess(aVoid -> log.debug("Successfully set SecurityContext"));
+                .doOnSuccess(aVoid -> log.debug("Successfully set SecurityContext"))
+                .doOnError(e -> log.error("Error setting SecurityContext", e));
     }
 
 

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
           uri: lb://challenge
           predicates:
             - Path=/challenges/**
+#      default-filters:
+#        - name: AuthorityBasedRoutingFilter
   security:
     oauth2:
       client:

--- a/challenge/build.gradle
+++ b/challenge/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.jasypt:jasypt:1.9.3'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+	implementation 'org.springframework.data:spring-data-envers:3.3.1'
 
 	//open feign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
@@ -47,6 +48,12 @@ dependencies {
 	//server registry
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//Jwt
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+
 }
 
 dependencyManagement {

--- a/challenge/build.gradle
+++ b/challenge/build.gradle
@@ -23,14 +23,36 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.2")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.jasypt:jasypt:1.9.3'
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+	//open feign
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	//server registry
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+	}
 }
 
 tasks.named('test') {

--- a/challenge/src/main/java/com/zerobase/challenge/ChallengeApplication.java
+++ b/challenge/src/main/java/com/zerobase/challenge/ChallengeApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
@@ -16,6 +17,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableEncryptableProperties
 @PropertySource(name="EncryptedProperties", value = "classpath:application-challenge.yml")
 @EnableFeignClients
+@EnableJpaAuditing
 public class ChallengeApplication {
 
 	public static void main(String[] args) {

--- a/challenge/src/main/java/com/zerobase/challenge/ChallengeApplication.java
+++ b/challenge/src/main/java/com/zerobase/challenge/ChallengeApplication.java
@@ -1,13 +1,24 @@
 package com.zerobase.challenge;
 
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
+@EnableDiscoveryClient
+@EntityScan(basePackages = "com.zerobase")
+@EnableEncryptableProperties
+@PropertySource(name="EncryptedProperties", value = "classpath:application-challenge.yml")
+@EnableFeignClients
 public class ChallengeApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ChallengeApplication.class, args);
 	}
-
 }

--- a/challenge/src/main/java/com/zerobase/challenge/client/MemberFeignClient.java
+++ b/challenge/src/main/java/com/zerobase/challenge/client/MemberFeignClient.java
@@ -1,6 +1,6 @@
 package com.zerobase.challenge.client;
 
-import com.zerobase.user.dto.MemberDto;
+import com.zerobase.challenge.domain.dto.MemberDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/challenge/src/main/java/com/zerobase/challenge/config/Jasypt.java
+++ b/challenge/src/main/java/com/zerobase/challenge/config/Jasypt.java
@@ -1,0 +1,39 @@
+package com.zerobase.challenge.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Jasypt {
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password); // 암호화 키 값
+        config.setAlgorithm("PBEWithMD5AndDES"); // 암호 알고리즘
+        config.setKeyObtentionIterations("1000"); // PBE 해쉬 횟수
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+
+    public void getEnc() {
+        StandardPBEStringEncryptor standardPBEStringEncryptor = new StandardPBEStringEncryptor();
+        standardPBEStringEncryptor.setAlgorithm("PBEWithMD5AndDES");
+        standardPBEStringEncryptor.setPassword("TEST_KEY");
+        String enc = standardPBEStringEncryptor.encrypt("password123");
+        System.out.println("Encrypted Password is : "+ enc);
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/controller/ChallengeController.java
+++ b/challenge/src/main/java/com/zerobase/challenge/controller/ChallengeController.java
@@ -1,0 +1,48 @@
+package com.zerobase.challenge.controller;
+
+import com.zerobase.challenge.domain.dto.CreateChallengeForm;
+import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
+import com.zerobase.challenge.service.ChallengeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/challenges")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+    @PostMapping
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> create(
+            @RequestHeader(name = "Authorization") String token,
+            @Valid @RequestBody CreateChallengeForm createChallengeForm
+    ) throws Exception {
+        return ResponseEntity.ok(
+                challengeService.createChallenge(token, createChallengeForm)
+        );
+    }
+
+    @PutMapping
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> update(
+            @RequestHeader(name = "Authorization") String token,
+            @Valid @RequestBody UpdateChallengeForm updateChallengeForm
+    ) throws Exception {
+        return ResponseEntity.ok(challengeService.updateChallenge(token, updateChallengeForm));
+    }
+
+    @PutMapping("/cancel")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> cancelStatus(
+            @RequestHeader(name = "Authorization") String token,
+            @RequestParam Long challengeId
+    ) throws Exception {
+        return ResponseEntity.ok(
+                challengeService.cancelStatus(token, challengeId)
+        );
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/controller/ChallengeController.java
+++ b/challenge/src/main/java/com/zerobase/challenge/controller/ChallengeController.java
@@ -5,6 +5,7 @@ import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
 import com.zerobase.challenge.service.ChallengeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/challenges")
+@Slf4j
 public class ChallengeController {
 
     private final ChallengeService challengeService;
@@ -45,4 +47,33 @@ public class ChallengeController {
                 challengeService.cancelStatus(token, challengeId)
         );
     }
+
+    @GetMapping("/list")
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> getChallenges(
+            @RequestHeader(name = "Authorization") String token
+    ) throws Exception {
+        return ResponseEntity.ok(challengeService.getChallenges(token));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> getChallenge(
+            @RequestHeader(name = "Authorization") String token,
+            @RequestParam Long challengeId
+    ) throws Exception {
+        return ResponseEntity.ok(challengeService.getChallenge(token, challengeId));
+    }
+
+    @DeleteMapping
+    @PreAuthorize("hasRole('USER')")
+    public ResponseEntity<?> deleteChallenge(
+            @RequestHeader(name = "Authorization") String token,
+            @RequestParam Long challengeId
+    ) throws Exception {
+        challengeService.deleteChallenge(token, challengeId);
+        log.info("{} 챌린지를 삭제하였습니다.", challengeId);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/challenge/src/main/java/com/zerobase/challenge/customAnnotation/StartDate.java
+++ b/challenge/src/main/java/com/zerobase/challenge/customAnnotation/StartDate.java
@@ -1,0 +1,18 @@
+package com.zerobase.challenge.customAnnotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = StartDateValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StartDate {
+    String message() default "시작 날짜는 현재 날짜부터 가능합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/challenge/src/main/java/com/zerobase/challenge/customAnnotation/StartDateValidator.java
+++ b/challenge/src/main/java/com/zerobase/challenge/customAnnotation/StartDateValidator.java
@@ -1,0 +1,21 @@
+package com.zerobase.challenge.customAnnotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+
+public class StartDateValidator implements ConstraintValidator<StartDate, LocalDate> {
+
+    @Override
+    public void initialize(StartDate constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(LocalDate startDate, ConstraintValidatorContext context) {
+        if (startDate == null) {
+            return true; // @NotNull 이 null case를 다룸
+        }
+        return !startDate.isBefore(LocalDate.now());
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChallengeResponseDto.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChallengeResponseDto.java
@@ -1,0 +1,23 @@
+package com.zerobase.challenge.domain.dto;
+
+import com.zerobase.challenge.domain.enums.Category;
+import com.zerobase.challenge.domain.enums.ChallengeStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+public class ChallengeResponseDto {
+    private Long id;
+    private String username;
+    private String title;
+    private Category category;
+    private String goal;
+    private LocalDate startDate;
+    private LocalDate dueDate;
+    private String description;
+    private ChallengeStatus status;
+
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChallengeResponseDto.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChallengeResponseDto.java
@@ -4,13 +4,16 @@ import com.zerobase.challenge.domain.enums.Category;
 import com.zerobase.challenge.domain.enums.ChallengeStatus;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Builder
 @Getter
 public class ChallengeResponseDto {
     private Long id;
+    private Long userId;
     private String username;
     private String title;
     private Category category;
@@ -19,5 +22,20 @@ public class ChallengeResponseDto {
     private LocalDate dueDate;
     private String description;
     private ChallengeStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastModifiedAt;
 
+    @Builder
+    @Getter
+    @Setter
+    public static class ChallengeSimpleDto {
+        private Long id;
+        private String username;
+        private String title;
+        private ChallengeStatus status;
+        private LocalDate startDate;
+        private LocalDate dueDate;
+        private LocalDateTime createdAt;
+        private LocalDateTime lastModifiedAt;
+    }
 }

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChangeChallengeForm.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/ChangeChallengeForm.java
@@ -1,0 +1,15 @@
+package com.zerobase.challenge.domain.dto;
+
+import com.zerobase.challenge.domain.enums.Category;
+
+import java.time.LocalDate;
+
+public interface ChangeChallengeForm {
+
+    Long getUserId();
+    Category getCategory();
+    String getGoal();
+    LocalDate getStartDate();
+    LocalDate getDueDate();
+    String getDescription();
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/CreateChallengeForm.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/CreateChallengeForm.java
@@ -1,0 +1,59 @@
+package com.zerobase.challenge.domain.dto;
+
+import com.zerobase.challenge.customAnnotation.StartDate;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.enums.Category;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+public class CreateChallengeForm implements ChangeChallengeForm{
+
+    private Long userId;
+
+    @NotNull
+    private String username;
+    @NotNull
+    private String title;
+    @NotNull(message = "분야를 설정해주세요.")
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @NotNull(message = "목표를 입력해주세요.")
+    @Size(max = 100, message = "목표는 100자 이내로 입력해주세요.")
+    private String goal;
+
+    @NotNull(message = "시작 날짜를 입력해주세요.")
+    @StartDate(message = "현재 날짜부터 입력이 가능합니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "목표 날짜를 입력해주세요.")
+    @Future(message = "시작 날짜로부터 최소 1개월 이후부터 입력가능합니다.")
+    private LocalDate dueDate;
+
+    @Size(max = 1000, message = "기타 설명은 1000자 이내로 입력해주세요.")
+    private String description;
+
+    public ChallengeEntity toEntity() {
+        return ChallengeEntity.builder()
+                .userId(userId)
+                .username(username)
+                .title(title)
+                .category(category)
+                .goal(goal)
+                .startDate(startDate)
+                .dueDate(dueDate)
+                .description(description)
+                .build();
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/MemberDto.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/MemberDto.java
@@ -1,0 +1,33 @@
+package com.zerobase.challenge.domain.dto;
+
+import com.zerobase.challenge.domain.enums.Gender;
+import com.zerobase.challenge.domain.enums.MemberLevel;
+import com.zerobase.challenge.domain.enums.Provider;
+import com.zerobase.challenge.domain.enums.Role;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class MemberDto {
+    private Long id;
+    private String username;
+    private String email;
+    private String phoneNumber;
+    private String nickName;
+    private String name;
+    private LocalDate birth;
+    private String job;
+    private String interests;
+    private Gender gender;
+    private Long points;
+    private Provider provider;
+    private String providerId;
+    private MemberLevel level;
+    private List<Role> roles;
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/dto/UpdateChallengeForm.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/dto/UpdateChallengeForm.java
@@ -1,0 +1,64 @@
+package com.zerobase.challenge.domain.dto;
+
+import com.zerobase.challenge.customAnnotation.StartDate;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.enums.Category;
+import com.zerobase.challenge.domain.enums.ChallengeStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class UpdateChallengeForm implements ChangeChallengeForm{
+
+    private Long userId;
+
+    @NotNull
+    private String title;
+
+    @NotNull(message = "수정할 챌린지를 선택해주세요.")
+    private Long challengeId;
+
+    @NotNull(message = "분야를 설정해주세요.")
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @NotNull(message = "목표를 입력해주세요.")
+    @Size(max = 100, message = "목표는 100자 이내로 입력해주세요.")
+    private String goal;
+
+    @NotNull(message = "시작 날짜를 입력해주세요.")
+    @StartDate(message = "현재 날짜부터 입력이 가능합니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "목표 날짜를 입력해주세요.")
+    @Future(message = "시작 날짜로부터 최소 1개월 이후부터 입력가능합니다.")
+    private LocalDate dueDate;
+
+    @Size(max = 1000, message = "기타 설명은 1000자 이내로 입력해주세요.")
+    private String description;
+
+    public ChallengeEntity toUpdatedChallengeEntity(
+            Long challengeId, Long userId, String username, ChallengeStatus status
+    ) {
+        return ChallengeEntity.builder()
+                .id(challengeId)
+                .userId(userId)
+                .username(username)
+                .title(title)
+                .category(category)
+                .goal(goal)
+                .startDate(startDate)
+                .dueDate(dueDate)
+                .description(description)
+                .status(status)
+                .build();
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/entity/BaseEntity.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.zerobase.challenge.domain.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter // test용
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/entity/ChallengeEntity.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/entity/ChallengeEntity.java
@@ -1,0 +1,64 @@
+package com.zerobase.challenge.domain.entity;
+
+import com.zerobase.challenge.domain.dto.ChallengeResponseDto;
+import com.zerobase.challenge.domain.enums.Category;
+import com.zerobase.challenge.domain.enums.ChallengeStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity(name = "challenge")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Column(nullable = false, length = 100)
+    private String goal;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate dueDate;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ChallengeStatus status;
+
+    public ChallengeResponseDto toResponseDto() {
+        return ChallengeResponseDto.builder()
+                .id(id)
+                .username(username)
+                .title(title)
+                .category(category)
+                .goal(goal)
+                .startDate(startDate)
+                .dueDate(dueDate)
+                .description(description)
+                .status(status)
+                .build();
+    }
+
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/entity/ChallengeEntity.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/entity/ChallengeEntity.java
@@ -5,6 +5,7 @@ import com.zerobase.challenge.domain.enums.Category;
 import com.zerobase.challenge.domain.enums.ChallengeStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.envers.AuditOverride;
 
 import java.time.LocalDate;
 
@@ -14,11 +15,13 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChallengeEntity {
+@AuditOverride(forClass = BaseEntity.class)
+public class ChallengeEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long userId;
 
     @Column(nullable = false)
@@ -47,9 +50,10 @@ public class ChallengeEntity {
     @Enumerated(EnumType.STRING)
     private ChallengeStatus status;
 
-    public ChallengeResponseDto toResponseDto() {
+    public ChallengeResponseDto toChallengeDto() {
         return ChallengeResponseDto.builder()
                 .id(id)
+                .userId(userId)
                 .username(username)
                 .title(title)
                 .category(category)
@@ -58,6 +62,21 @@ public class ChallengeEntity {
                 .dueDate(dueDate)
                 .description(description)
                 .status(status)
+                .createdAt(getCreatedAt())
+                .lastModifiedAt(getLastModifiedAt())
+                .build();
+    }
+
+    public ChallengeResponseDto.ChallengeSimpleDto toChallengeSimpleDto() {
+        return ChallengeResponseDto.ChallengeSimpleDto.builder()
+                .id(id)
+                .username(username)
+                .title(title)
+                .status(status)
+                .startDate(startDate)
+                .dueDate(dueDate)
+                .createdAt(getCreatedAt())
+                .lastModifiedAt(getLastModifiedAt())
                 .build();
     }
 

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/Category.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/Category.java
@@ -1,0 +1,22 @@
+package com.zerobase.challenge.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Category {
+    LANGUAGE("언어"),
+    DEGREE("학위"),
+    EXAM("시험"),
+    IT("IT"),
+    MUSIC("음악"),
+    ART("미술"),
+    SPORTS("스포츠"),
+    LITERATURE("문학"),
+    PHOTOGRAPHY("사진"),
+    VIDEO("영상"),
+    OTHER("기타");
+
+    private final String displayName;
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/ChallengeStatus.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/ChallengeStatus.java
@@ -1,0 +1,14 @@
+package com.zerobase.challenge.domain.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum ChallengeStatus {
+    PENDING("대기 중"),
+    ONGOING("진행 중"),
+    COMPLETED("완료"),
+    EXPIRED("기간 만료"),
+    CANCELLED("취소");
+
+    private final String displayName;
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/Gender.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.zerobase.challenge.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/MemberLevel.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/MemberLevel.java
@@ -1,0 +1,5 @@
+package com.zerobase.challenge.domain.enums;
+
+public enum MemberLevel {
+    BEGINNER, BRONZE, SILVER, GOLD, MASTER
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/Provider.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/Provider.java
@@ -1,0 +1,40 @@
+package com.zerobase.challenge.domain.enums;
+
+
+import com.zerobase.challenge.domain.oauth2User.GoogleUserInfo;
+import com.zerobase.challenge.domain.oauth2User.KakaoUserInfo;
+import com.zerobase.challenge.domain.oauth2User.NaverUserInfo;
+import com.zerobase.challenge.domain.oauth2User.SocialUserInfo;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public enum Provider {
+    GOOGLE("sub"){
+        @Override
+        public GoogleUserInfo createUserInfo(Map<String, Object> attributes) {
+            return new GoogleUserInfo(attributes);
+        }
+    },
+    NAVER("response"){
+        @Override
+        public NaverUserInfo createUserInfo(Map<String, Object> attributes) {
+            return new NaverUserInfo(attributes);
+        }
+    },
+    KAKAO("id"){
+        @Override
+        public KakaoUserInfo createUserInfo(Map<String, Object> attributes) {
+            return new KakaoUserInfo(attributes);
+        }
+    };
+
+    private final String userNameAttribute;
+
+    Provider(String userNameAttribute) {
+        this.userNameAttribute = userNameAttribute;
+    }
+
+    public abstract SocialUserInfo createUserInfo(Map<String, Object> attributes);
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/enums/Role.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.zerobase.challenge.domain.enums;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/GoogleUserInfo.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/GoogleUserInfo.java
@@ -1,0 +1,28 @@
+package com.zerobase.challenge.domain.oauth2User;
+
+
+import com.zerobase.challenge.domain.enums.Provider;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("sub");    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/KakaoUserInfo.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/KakaoUserInfo.java
@@ -1,0 +1,31 @@
+package com.zerobase.challenge.domain.oauth2User;
+
+
+import com.zerobase.challenge.domain.enums.Provider;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.KAKAO;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+
+    @Override
+    public String getName() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return (String) ((Map<String, Object>) kakaoAccount.get("profile")).get("nickname");
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/NaverUserInfo.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/NaverUserInfo.java
@@ -1,0 +1,32 @@
+package com.zerobase.challenge.domain.oauth2User;
+
+
+import com.zerobase.challenge.domain.enums.Provider;
+
+import java.util.Map;
+
+public class NaverUserInfo implements SocialUserInfo {
+    private final Map<String, Object> attributes;
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.NAVER;
+    }
+
+    @Override
+    public String getProviderId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("id");
+    }
+
+
+    @Override
+    public String getName() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return (String) response.get("name");
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/SocialUserInfo.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/oauth2User/SocialUserInfo.java
@@ -1,0 +1,10 @@
+package com.zerobase.challenge.domain.oauth2User;
+
+
+import com.zerobase.challenge.domain.enums.Provider;
+
+public interface SocialUserInfo {
+    Provider getProvider();
+    String getProviderId();
+    String getName();
+}

--- a/challenge/src/main/java/com/zerobase/challenge/domain/repository/ChallengeRepository.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/repository/ChallengeRepository.java
@@ -18,6 +18,16 @@ public interface ChallengeRepository extends JpaRepository<ChallengeEntity, Long
     @Query("SELECT c" +
             " FROM challenge c " +
             "WHERE c.id = :id AND " +
+            "c.userId = :userId AND " +
             "c.status <> 'COMPLETED' AND c.status <> 'EXPIRED'")
-    Optional<ChallengeEntity> findUpdatableById(Long id);
+    Optional<ChallengeEntity> findUpdatableByIdAndUserId(Long id, Long userId);
+
+    List<ChallengeEntity> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<ChallengeEntity> findByIdAndUserId(Long id, Long userId);
+
+
+    Optional<ChallengeEntity> findByIdAndUserIdAndStatusIn(
+            Long challengeId, Long userId, List<ChallengeStatus> statuses
+    );
 }

--- a/challenge/src/main/java/com/zerobase/challenge/domain/repository/ChallengeRepository.java
+++ b/challenge/src/main/java/com/zerobase/challenge/domain/repository/ChallengeRepository.java
@@ -1,0 +1,23 @@
+package com.zerobase.challenge.domain.repository;
+
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.enums.ChallengeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChallengeRepository extends JpaRepository<ChallengeEntity, Long> {
+    List<ChallengeEntity> findAllByUserId(Long userId);
+
+    List<ChallengeEntity> findByStatus(ChallengeStatus challengeStatus);
+
+    @Query("SELECT c" +
+            " FROM challenge c " +
+            "WHERE c.id = :id AND " +
+            "c.status <> 'COMPLETED' AND c.status <> 'EXPIRED'")
+    Optional<ChallengeEntity> findUpdatableById(Long id);
+}

--- a/challenge/src/main/java/com/zerobase/challenge/exception/CustomException.java
+++ b/challenge/src/main/java/com/zerobase/challenge/exception/CustomException.java
@@ -1,0 +1,8 @@
+package com.zerobase.challenge.exception;
+
+public class CustomException extends RuntimeException {
+    private ErrorCode errorCode;
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/exception/ErrorCode.java
+++ b/challenge/src/main/java/com/zerobase/challenge/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.zerobase.challenge.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    INVALID_CHALLENGE_DUEDATE(HttpStatus.BAD_REQUEST, "챌린지 진행 기간을 확인하세요"),
+    CHALLENGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 챌린지를 찾을 수 없습니다."),
+    UPDATABLE_CHALLENGE_NOT_FOUNT(HttpStatus.BAD_REQUEST, "수정 가능한 챌린지를 찾을 수 없습니다."),
+    SHORTEN_DUEDATE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 진행 중인 챌린지는 기한을 앞당길 수 없습니다."),
+    CHALLENGE_STATUS_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST,
+            "이미 진행 중이거나 완료 또는 만료 상태인 챌린지는 변경할 수 없습니다."),
+    DUPLICATE_CHALLENGE_PERIOD(
+            HttpStatus.BAD_REQUEST,
+            "요청한 기한 내에 이미 등록된 챌린지가 있습니다."),
+    INVALID_CHALLENGE_USER(HttpStatus.BAD_REQUEST,
+            "챌린지의 유저 아이디가 토큰 소유자의 아이디와 일치하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/challenge/src/main/java/com/zerobase/challenge/exception/ErrorCode.java
+++ b/challenge/src/main/java/com/zerobase/challenge/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     INVALID_CHALLENGE_DUEDATE(HttpStatus.BAD_REQUEST, "챌린지 진행 기간을 확인하세요"),
     CHALLENGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 챌린지를 찾을 수 없습니다."),
-    UPDATABLE_CHALLENGE_NOT_FOUNT(HttpStatus.BAD_REQUEST, "수정 가능한 챌린지를 찾을 수 없습니다."),
+    DELETABLE_CHALLENGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "삭제 가능한 챌린지를 찾을 수 없습니다."),
+    UPDATABLE_CHALLENGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "수정 가능한 챌린지를 찾을 수 없습니다."),
     SHORTEN_DUEDATE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 진행 중인 챌린지는 기한을 앞당길 수 없습니다."),
     CHALLENGE_STATUS_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST,
             "이미 진행 중이거나 완료 또는 만료 상태인 챌린지는 변경할 수 없습니다."),

--- a/challenge/src/main/java/com/zerobase/challenge/security/JwtAuthenticationFilter.java
+++ b/challenge/src/main/java/com/zerobase/challenge/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.zerobase.challenge.security;
+
+
+import com.zerobase.challenge.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final String ACCESS_TOKEN_HEADER = "Authorization";
+    private final String TOKEN_PREFIX = "Bearer ";
+
+    //본인의 토큰이 맞고 유효기간이 지나지 않았을 때
+    // 토큰이 없거나 유효하지 않은 경우 필터 체인으로 넘깁니다.
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+        String accessJwt = resolveToken(request, ACCESS_TOKEN_HEADER);
+        log.debug("request path: {}", request.getRequestURI());
+        log.debug("accessJwt: {}", accessJwt);
+        if (accessJwt != null &&
+                jwtUtil.validateToken(jwtUtil.extractUsername(accessJwt), accessJwt)) {
+            Authentication authentication = jwtUtil.getAuthentication(accessJwt);
+            log.info("Filtering request token Authentication: {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.info(String.format("[%s] -> %s ",
+                    jwtUtil.extractUsername(accessJwt), request.getRequestURI())
+            );
+        }
+        log.info("Filtering request token: {}", accessJwt);
+        log.info("authentication: {}", SecurityContextHolder.getContext().getAuthentication());
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request, String header) {
+        String token = request.getHeader(header);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/security/SecurityConfig.java
+++ b/challenge/src/main/java/com/zerobase/challenge/security/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.zerobase.challenge.security;
+
+import com.zerobase.challenge.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(request -> request
+                        .anyRequest().authenticated())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(
+                        jwtAuthenticationFilter(),
+                        UsernamePasswordAuthenticationFilter.class
+                );
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtUtil);
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/service/ChallengeFormValidator.java
+++ b/challenge/src/main/java/com/zerobase/challenge/service/ChallengeFormValidator.java
@@ -58,12 +58,13 @@ public class ChallengeFormValidator {
     }
 
     public void validateDuedate(ChangeChallengeForm changeChallengeForm) {
-        //dueDate 기간 안에 이미 등록한 챌린지가 있으면 등록 불가
+        //dueDate 기간 안에 이미 챌린지가 있으면 등록 불가
         boolean existOnGoingChallenge =
                 challengeRepository.findAllByUserId(changeChallengeForm.getUserId())
                         .stream()
-                        .anyMatch(challenge -> challenge.getStatus()
-                                .equals(ONGOING));
+                        .anyMatch(challenge ->
+                                challenge.getDueDate().isEqual(changeChallengeForm.getStartDate()) ||
+                                challenge.getDueDate().isAfter(changeChallengeForm.getStartDate()));
         if (existOnGoingChallenge) {
             throw new CustomException(ErrorCode.INVALID_CHALLENGE_DUEDATE);
         }

--- a/challenge/src/main/java/com/zerobase/challenge/service/ChallengeFormValidator.java
+++ b/challenge/src/main/java/com/zerobase/challenge/service/ChallengeFormValidator.java
@@ -1,0 +1,99 @@
+package com.zerobase.challenge.service;
+
+import com.zerobase.challenge.domain.dto.ChangeChallengeForm;
+import com.zerobase.challenge.domain.dto.CreateChallengeForm;
+import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.repository.ChallengeRepository;
+import com.zerobase.challenge.exception.CustomException;
+import com.zerobase.challenge.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+import static com.zerobase.challenge.domain.enums.ChallengeStatus.ONGOING;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeFormValidator {
+
+    private final ChallengeRepository challengeRepository;
+
+    public void validateCreateChallengeForm(
+            Long userId,
+            CreateChallengeForm createChallengeForm
+    ) {
+        //dueDate 기간 안에 이미 등록한 챌린지가 있으면 등록 불가
+        //dueDate는 시작날짜로부터 최소 1개월 이후 5년 이내
+        validateDuedate(createChallengeForm);
+        validateUserForm(userId, createChallengeForm);
+    }
+
+    public void validateUpdateChallengeForm(
+            ChallengeEntity challengeEntity,
+            UpdateChallengeForm updateChallengeForm
+    ) {
+        // 진행 중인 챌린지는 기존 dueDate를 앞당길 수 없음
+        if (challengeEntity.getStatus().equals(ONGOING) &&
+                updateChallengeForm.getDueDate()
+                        .isBefore(challengeEntity.getDueDate())
+        ) {
+            throw new CustomException(ErrorCode.SHORTEN_DUEDATE_NOT_AVAILABLE);
+        }
+
+        // 이미 진행 중이라면 시작 날짜 변경 불가
+        if (challengeEntity.getStatus().equals(ONGOING) &&
+                !challengeEntity.getStartDate()
+                        .equals(updateChallengeForm.getStartDate())
+        ) {
+            throw new CustomException(ErrorCode.CHALLENGE_STATUS_NOT_MODIFIABLE);
+        }
+        //dueDate 기간 안에 이미 등록한 챌린지가 있으면 등록 불가
+        //dueDate는 시작날짜로부터 최소 1개월 이후 5년 이내
+        validateDuedate(updateChallengeForm);
+        validateUserForm(updateChallengeForm.getUserId(), updateChallengeForm);
+    }
+
+    public void validateDuedate(ChangeChallengeForm changeChallengeForm) {
+        //dueDate 기간 안에 이미 등록한 챌린지가 있으면 등록 불가
+        boolean existOnGoingChallenge =
+                challengeRepository.findAllByUserId(changeChallengeForm.getUserId())
+                        .stream()
+                        .anyMatch(challenge -> challenge.getStatus()
+                                .equals(ONGOING));
+        if (existOnGoingChallenge) {
+            throw new CustomException(ErrorCode.INVALID_CHALLENGE_DUEDATE);
+        }
+
+        if(changeChallengeForm.getDueDate()
+                .isBefore(changeChallengeForm
+                        .getStartDate()
+                        .plusMonths(1)) ||
+                changeChallengeForm.getDueDate()
+                        .isAfter(changeChallengeForm
+                                .getDueDate()
+                                .plusYears(5))
+        ) {
+            throw new CustomException(ErrorCode.INVALID_CHALLENGE_DUEDATE);
+        }
+    }
+
+    //user의 아이디와 challenge의 소유자 아이디 일치 여부 확인
+    public void validateUserEntity(
+            Long userId, ChallengeEntity challengeEntity
+    ) {
+        if (!Objects.equals(userId, challengeEntity.getUserId())) {
+            throw new CustomException(ErrorCode.INVALID_CHALLENGE_USER);
+        }
+    }
+    public void validateUserForm(
+            Long userId, ChangeChallengeForm changeChallengeForm) {
+        log.debug("userId = {}, challengeForm UserId = {}", userId, changeChallengeForm.getUserId());
+        if (!Objects.equals(userId, changeChallengeForm.getUserId())) {
+            throw new CustomException(ErrorCode.INVALID_CHALLENGE_USER);
+        }
+    }
+}

--- a/challenge/src/main/java/com/zerobase/challenge/service/ChallengeService.java
+++ b/challenge/src/main/java/com/zerobase/challenge/service/ChallengeService.java
@@ -1,0 +1,120 @@
+package com.zerobase.challenge.service;
+
+import com.zerobase.challenge.client.MemberFeignClient;
+import com.zerobase.challenge.domain.dto.ChallengeResponseDto;
+import com.zerobase.challenge.domain.dto.CreateChallengeForm;
+import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.enums.ChallengeStatus;
+import com.zerobase.challenge.domain.repository.ChallengeRepository;
+import com.zerobase.challenge.exception.CustomException;
+import com.zerobase.challenge.exception.ErrorCode;
+import com.zerobase.challenge.domain.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+
+import static com.zerobase.challenge.domain.enums.ChallengeStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeService {
+
+    private final MemberFeignClient memberFeignClient;
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeFormValidator challengeFormValidator;
+
+    //챌린지 생성
+    public ChallengeResponseDto createChallenge(
+            String token,
+            CreateChallengeForm createChallengeForm
+    ) throws Exception {
+
+        Long userId = getUserId(token);
+        challengeFormValidator.validateCreateChallengeForm(
+                userId, createChallengeForm
+        );
+        //challengeEntity 생성 후 저장
+        //startDate가 오늘 날짜면 상태를 진행 중, 그렇지 않으면 대기 중으로 설정
+        ChallengeEntity challengeEntity = createChallengeForm.toEntity();
+        challengeEntity.setStatus(
+                createChallengeForm.getStartDate().equals(new Date()) ?
+                        ONGOING : PENDING
+        );
+        return challengeRepository.save(challengeEntity).toResponseDto();
+    }
+
+    @Scheduled(cron = "0 0 1 * * ?") // 매일 밤 1시에 실행
+    public void updateExpiredChallenges() {
+        List<ChallengeEntity> ongoingChallenges = challengeRepository.findByStatus(ONGOING);
+        ongoingChallenges.stream()
+                .filter(challenge -> challenge.getDueDate().isBefore(LocalDate.now()))
+                .forEach(challenge -> {
+                    challenge.setStatus(ChallengeStatus.EXPIRED);
+                    challengeRepository.save(challenge);
+                });
+    }
+
+    //챌린지 내용 수정
+    public ChallengeResponseDto updateChallenge(
+            String token,
+            UpdateChallengeForm updateChallengeForm
+    ) throws Exception {
+        ChallengeEntity challengeEntity =
+                challengeRepository.findUpdatableById(updateChallengeForm.getChallengeId())
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.UPDATABLE_CHALLENGE_NOT_FOUNT)
+                        );
+
+        //token 소유자의 아이디와 챌린지의 유저아이디 일치 확인
+        Long userId = getUserId(token);
+        challengeFormValidator.validateUserEntity(userId, challengeEntity);
+        //duedate & status 검증
+        challengeFormValidator.validateUpdateChallengeForm(
+                challengeEntity, updateChallengeForm
+        );
+
+        //엔티티 수정 (chaellengeId, userId, username은 기존 것으로 사용, 변경 불가)
+        ChallengeEntity updatedChallengeEntity =
+                updateChallengeForm.toUpdatedChallengeEntity(
+                        challengeEntity.getId(),
+                        challengeEntity.getUserId(),
+                        challengeEntity.getUsername(),
+                        challengeEntity.getStatus()
+                );
+
+        ChallengeEntity updatedChallenge =
+                challengeRepository.save(updatedChallengeEntity);
+        return updatedChallenge.toResponseDto();
+    }
+
+    //챌린지 취소
+    public ChallengeResponseDto cancelStatus(
+            String token, Long challengeId
+            ) throws Exception {
+        ChallengeEntity challengeEntity = challengeRepository
+                .findUpdatableById(challengeId)
+                .orElseThrow(
+                        () -> new CustomException(ErrorCode.UPDATABLE_CHALLENGE_NOT_FOUNT)
+                );
+
+        //token 소유자의 아이디와 챌린지의 유저아이디 일치 확인
+        Long userId = getUserId(token);
+        challengeFormValidator.validateUserEntity(userId, challengeEntity);
+
+        // 챌린지 상태 정보 수정
+        challengeEntity.setStatus(CANCELLED);
+
+        return challengeRepository.save(challengeEntity).toResponseDto();
+    }
+
+    private Long getUserId(String token) throws Exception {
+        MemberDto memberDto = memberFeignClient.userInfo(token).getBody();
+        return memberDto.getId();
+    }
+}
+

--- a/challenge/src/main/java/com/zerobase/challenge/util/JwtUtil.java
+++ b/challenge/src/main/java/com/zerobase/challenge/util/JwtUtil.java
@@ -1,6 +1,7 @@
-package com.zerobase.apigateway.util;
+package com.zerobase.challenge.util;
 
-import com.zerobase.apigateway.enums.Role;
+
+import com.zerobase.challenge.domain.enums.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
@@ -113,3 +114,4 @@ public class JwtUtil {
                 "", userDetails.getAuthorities());
     }
 }
+

--- a/challenge/src/main/resources/application-challenge.yml
+++ b/challenge/src/main/resources/application-challenge.yml
@@ -1,0 +1,47 @@
+
+server:
+  port: 8082
+
+spring:
+  application:
+    name: challenge
+  datasource:
+    url: ENC(cGjAWFkRj3kGcJQCycAFNIV0oxhrFN6Bcl7hMhZ5YY1l8L9r4mFgjoTpKpeUgyUfqJRsfZWDBe5tyuMy1TDlETGLRFhUzNZY)
+    username: ENC(YwS1VR1NKFYkgTpJoFd4s0rP5VT0CZbs)
+    password: ENC(MqwgTk7hSognuNoHqSChFudMokjZcFXS)
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+eureka:
+  instance:
+    prefer-ip-address: true
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
+jwt:
+  secret: ENC(nv2zQD07ToGj4ULUjnwOrWI+5wjIQo6GE4QZFbDiGSenOxv1G714D0DUZKznorOX85bUP+yTSl8=)
+
+aes:
+  password: ENC(yGEk/YjqUhn34BwblUO5mQapkJ/2A+J3ux4JRuYFTiTEkXjy7D5hp5tZNATimMjOopJlQZaMmVk=)
+  salt: ENC(g/sMb9wlbW7WYrHl4AyKfz0lehFy5An7RIQXR2FpFs63onbNvMCrkQ==)
+
+jasypt:
+  encryptor:
+    property:
+      bean: jasyptStringEncryptor
+    password: ${SECRET_KEY}

--- a/challenge/src/main/resources/application.yml
+++ b/challenge/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: challenge

--- a/challenge/src/test/java/com/zerobase/challenge/service/ChallengeFormValidatorTest.java
+++ b/challenge/src/test/java/com/zerobase/challenge/service/ChallengeFormValidatorTest.java
@@ -1,0 +1,200 @@
+package com.zerobase.challenge.service;
+
+import com.zerobase.challenge.domain.dto.CreateChallengeForm;
+import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.enums.Category;
+import com.zerobase.challenge.domain.repository.ChallengeRepository;
+import com.zerobase.challenge.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.zerobase.challenge.domain.enums.ChallengeStatus.ONGOING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeFormValidatorTest {
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @InjectMocks
+    private ChallengeFormValidator challengeFormValidator;
+
+    private CreateChallengeForm createChallengeForm;
+    private UpdateChallengeForm updateChallengeForm;
+    private ChallengeEntity challengeEntity;
+
+
+    @BeforeEach
+    void setUp() {
+        createChallengeForm = CreateChallengeForm.builder()
+                .userId(1L)
+                .title("Title")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2026, 1, 1))
+                .description("Description")
+                .build();
+
+        updateChallengeForm = UpdateChallengeForm.builder()
+                .challengeId(1L)
+                .userId(1L)
+                .title("Update Title")
+                .category(Category.LANGUAGE)
+                .goal("update")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2025, 3, 1))
+                .description("Update Description")
+                .build();
+
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .title("Existing Challenge")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.now().minusDays(10))
+                .dueDate(LocalDate.now().plusMonths(1).plusDays(10))
+                .description("Existing Description")
+                .status(ONGOING)
+                .build();
+    }
+    //챌린지 기간이 1개월 미만일 때
+    @Test
+    void validateCreateChallengeForm_dueDateIsBeforeStartDate() {
+        //given
+        createChallengeForm = CreateChallengeForm.builder()
+                .userId(1L)
+                .title("Title")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2025, 1, 8))
+                .description("Description")
+                .build();
+
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateCreateChallengeForm(1L, createChallengeForm);
+        });
+        //then
+        assertEquals("챌린지 진행 기간을 확인하세요", exception.getMessage());
+    }
+
+    //아직 진행 중인 챌린지가 있을 때
+    @Test
+    void validateCreateChallengeForm_OngoingChallengeAlreadyExists() {
+        //given
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .status(ONGOING)
+                .build();
+
+        when(challengeRepository.findAllByUserId(1L)).thenReturn(List.of(challengeEntity));
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateCreateChallengeForm(1L, createChallengeForm);
+        });
+        //then
+        assertEquals("챌린지 진행 기간을 확인하세요", exception.getMessage());
+    }
+
+    @Test
+    void validateUpdateChallengeForm_whenDueDateIsShortened() {
+        //given
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .title("Existing Challenge")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2025, 3, 1))
+                .description("Existing Description")
+                .status(ONGOING)
+                .build();
+        updateChallengeForm = updateChallengeForm.builder()
+                .dueDate(LocalDate.of(2025, 2, 2))
+                .build();
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateUpdateChallengeForm(challengeEntity, updateChallengeForm);
+        });
+        //then
+        assertEquals("이미 진행 중인 챌린지는 기한을 앞당길 수 없습니다.", exception.getMessage());
+    }
+
+    // 이미 진행 중이라면 시작 날짜 변경 불가
+    @Test
+    void validateUpdateChallengeForm_shouldThrowException_whenStartDateIsChanged() {
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .title("Existing Challenge")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2025, 3, 1))
+                .description("Existing Description")
+                .status(ONGOING)
+                .build();
+        updateChallengeForm = updateChallengeForm.builder()
+                .startDate(LocalDate.of(2024, 12, 31))
+                .dueDate(LocalDate.of(2025, 3, 1))
+                .build();
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateUpdateChallengeForm(challengeEntity, updateChallengeForm);
+        });
+        //then
+        assertEquals("이미 진행 중이거나 완료 또는 만료 상태인 챌린지는 변경할 수 없습니다.", exception.getMessage());
+    }
+
+    @Test
+    void validateUserEntity_UserIdNotMatch() {
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(2L)
+                .title("Existing Challenge")
+                .category(Category.LANGUAGE)
+                .goal("master")
+                .startDate(LocalDate.of(2025, 1, 1))
+                .dueDate(LocalDate.of(2025, 3, 1))
+                .description("Existing Description")
+                .status(ONGOING)
+                .build();
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateUserEntity(1L, challengeEntity);
+        });
+        //then
+        assertEquals("챌린지의 유저 아이디가 토큰 소유자의 아이디와 일치하지 않습니다.",
+                exception.getMessage());
+    }
+
+    @Test
+    void validateUserForm_shouldThrowException_whenUserIdDoesNotMatch() {
+        //then
+        updateChallengeForm = updateChallengeForm.builder()
+                .userId(2L)
+                .build();
+        //when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            challengeFormValidator.validateUserForm(1L, updateChallengeForm);
+        });
+        //then
+        assertEquals("챌린지의 유저 아이디가 토큰 소유자의 아이디와 일치하지 않습니다.", exception.getMessage());
+    }
+}

--- a/challenge/src/test/java/com/zerobase/challenge/service/ChallengeFormValidatorTest.java
+++ b/challenge/src/test/java/com/zerobase/challenge/service/ChallengeFormValidatorTest.java
@@ -34,7 +34,6 @@ class ChallengeFormValidatorTest {
     private UpdateChallengeForm updateChallengeForm;
     private ChallengeEntity challengeEntity;
 
-
     @BeforeEach
     void setUp() {
         createChallengeForm = CreateChallengeForm.builder()
@@ -70,6 +69,7 @@ class ChallengeFormValidatorTest {
                 .status(ONGOING)
                 .build();
     }
+
     //챌린지 기간이 1개월 미만일 때
     @Test
     void validateCreateChallengeForm_dueDateIsBeforeStartDate() {
@@ -111,6 +111,7 @@ class ChallengeFormValidatorTest {
         assertEquals("챌린지 진행 기간을 확인하세요", exception.getMessage());
     }
 
+    //진행 중인 챌린지의 마감 기한을 앞당겼을 때
     @Test
     void validateUpdateChallengeForm_whenDueDateIsShortened() {
         //given

--- a/challenge/src/test/java/com/zerobase/challenge/service/ChallengeServiceTest.java
+++ b/challenge/src/test/java/com/zerobase/challenge/service/ChallengeServiceTest.java
@@ -1,0 +1,224 @@
+package com.zerobase.challenge.service;
+
+import com.zerobase.challenge.client.MemberFeignClient;
+import com.zerobase.challenge.domain.dto.ChallengeResponseDto;
+import com.zerobase.challenge.domain.dto.CreateChallengeForm;
+import com.zerobase.challenge.domain.dto.UpdateChallengeForm;
+import com.zerobase.challenge.domain.entity.ChallengeEntity;
+import com.zerobase.challenge.domain.repository.ChallengeRepository;
+import com.zerobase.challenge.exception.CustomException;
+import com.zerobase.challenge.exception.ErrorCode;
+import com.zerobase.challenge.domain.dto.MemberDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static com.zerobase.challenge.domain.enums.Category.LANGUAGE;
+import static com.zerobase.challenge.domain.enums.ChallengeStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeServiceTest {
+
+    @InjectMocks
+    private ChallengeService challengeService;
+
+    @Mock
+    private MemberFeignClient memberFeignClient;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Mock
+    private ChallengeFormValidator challengeFormValidator;
+
+    private String token;
+    private MemberDto memberDto;
+    private ChallengeEntity challengeEntity;
+
+
+    @Test
+    public void createChallenge_Success() throws Exception {
+        //given
+        token = "Bearer testToken";
+        memberDto = MemberDto.builder()
+                .id(1L)
+                .build();
+
+        CreateChallengeForm createChallengeForm = CreateChallengeForm.builder()
+                .title("Test Challenge")
+                .username("testUser")
+                .goal("Goal Test")
+                .startDate(LocalDate.of(2024, 8, 1))
+                .dueDate(LocalDate.of(2025, 8, 1))
+                .description("test description")
+                .build();
+
+        ChallengeEntity challengeEntity = createChallengeForm.toEntity();
+        challengeEntity.setStatus(
+                createChallengeForm.getStartDate().equals(new Date()) ?
+                ONGOING : PENDING
+        );
+
+        when(memberFeignClient.userInfo(token)).thenReturn(ResponseEntity.ok(memberDto));
+        when(challengeRepository.save(any(ChallengeEntity.class))).thenReturn(challengeEntity);
+
+        //when
+        ChallengeResponseDto result = challengeService.createChallenge(token, createChallengeForm);
+
+        assertNotNull(result);
+        assertEquals("Test Challenge", result.getTitle());
+        assertEquals("testUser", result.getUsername());
+        assertEquals("Goal Test", result.getGoal());
+        assertEquals(LocalDate.of(2024, 8, 1), result.getStartDate());
+        assertEquals(LocalDate.of(2025, 8, 1), result.getDueDate());
+        assertEquals(PENDING, result.getStatus());
+
+        verify(challengeRepository, times(1)).save(any(ChallengeEntity.class));
+        verify(challengeFormValidator, times(1)).validateCreateChallengeForm(anyLong(), any());
+    }
+
+
+    //dueDate는 시작날짜로부터 최소 1개월 이후 5년 이내
+    @Test
+    void createChallenge_fail_dueDate_tooShort() throws Exception {
+        //given
+
+        token = "Bearer testToken";
+        memberDto = MemberDto.builder()
+                .id(1L)
+                .build();
+        CreateChallengeForm createChallengeForm = CreateChallengeForm.builder()
+                .startDate(LocalDate.of(2024, 8, 1))
+                .dueDate(LocalDate.of(2025, 8, 31))
+                .build();
+        challengeEntity = createChallengeForm.toEntity();
+
+        when(memberFeignClient.userInfo(token)).thenReturn(ResponseEntity.ok(memberDto));
+        doThrow(new CustomException(ErrorCode.INVALID_CHALLENGE_DUEDATE))
+                .when(challengeFormValidator)
+                .validateCreateChallengeForm(
+                        anyLong(), any(CreateChallengeForm.class));
+        //when
+        CustomException exception =
+                assertThrows(CustomException.class,
+                        () -> challengeService
+                                .createChallenge(token, createChallengeForm));
+        //then
+        assertNotNull(exception);
+        assertEquals("챌린지 진행 기간을 확인하세요", exception.getMessage());
+    }
+
+    @Test
+    public void updateChallenge_Success() throws Exception {
+        //given
+        token = "Bearer testToken";
+        memberDto = MemberDto.builder()
+                .id(1L)
+                .build();
+
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .userId(1L)
+                .title("Test Challenge")
+                .category(LANGUAGE)
+                .goal("Run 5km")
+                .startDate(LocalDate.now())
+                .dueDate(LocalDate.now().plusMonths(1))
+                .description("Test Description")
+                .status(PENDING)
+                .build();
+
+        UpdateChallengeForm updateChallengeForm = UpdateChallengeForm.builder()
+                .challengeId(1L)
+                .title("Updated Challenge")
+                .category(LANGUAGE)
+                .startDate(LocalDate.of(2024, 8, 2))
+                .dueDate(LocalDate.of(2025, 8, 2))
+                .description("updated description")
+                .build();
+
+        ChallengeEntity updatedChallengeEntity =
+                updateChallengeForm.toUpdatedChallengeEntity(
+                        challengeEntity.getId(),
+                        challengeEntity.getUserId(),
+                        challengeEntity.getUsername(),
+                        challengeEntity.getStatus()
+                );
+
+        when(challengeRepository.findUpdatableById(1L)).thenReturn(Optional.of(challengeEntity));
+        when(memberFeignClient.userInfo(token)).thenReturn(ResponseEntity.ok(memberDto));
+        when(challengeRepository.save(any(ChallengeEntity.class))).thenReturn(updatedChallengeEntity);
+
+        //when
+        ChallengeResponseDto result = challengeService.updateChallenge(token, updateChallengeForm);
+
+        assertNotNull(result);
+        assertEquals("Updated Challenge", result.getTitle());
+        assertEquals("updated description", result.getDescription());
+        assertEquals(LANGUAGE, result.getCategory());
+        assertEquals(LocalDate.of(2024, 8, 2), result.getStartDate());
+        assertEquals(LocalDate.of(2025, 8, 2), result.getDueDate());
+        assertEquals(PENDING, result.getStatus());
+        verify(challengeRepository, times(1)).save(any(ChallengeEntity.class));
+        verify(challengeFormValidator, times(1)).validateUpdateChallengeForm(any(), any());
+    }
+
+    @Test
+    public void cancelStatus_Success() throws Exception {
+        //given
+        token = "Bearer testToken";
+        memberDto = MemberDto.builder()
+                .id(1L)
+                .build();
+        challengeEntity = ChallengeEntity.builder()
+                .id(1L)
+                .status(PENDING)
+                .build();
+
+
+
+        when(challengeRepository.findUpdatableById(1L)).thenReturn(Optional.of(challengeEntity));
+        when(memberFeignClient.userInfo(token)).thenReturn(ResponseEntity.ok(memberDto));
+        challengeEntity.setStatus(CANCELLED);
+        when(challengeRepository.save(any(ChallengeEntity.class))).thenReturn(challengeEntity);
+
+        //when
+        ChallengeResponseDto result = challengeService.cancelStatus(token, 1L);
+
+        //then
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        assertEquals(CANCELLED, result.getStatus());
+        verify(challengeRepository, times(1)).save(any(ChallengeEntity.class));
+        verify(challengeFormValidator, times(1)).validateUserEntity(anyLong(), any());
+    }
+
+    @Test
+    public void updateExpiredChallenges_Success() {
+        //given
+        challengeEntity = ChallengeEntity.builder()
+                .dueDate(LocalDate.now().minusDays(1))
+                .status(ONGOING).build();
+
+        when(challengeRepository.findByStatus(ONGOING)).thenReturn(List.of(challengeEntity));
+        when(challengeRepository.save(any(ChallengeEntity.class))).thenReturn(challengeEntity);
+
+        //when
+        challengeService.updateExpiredChallenges();
+
+        //then
+        verify(challengeRepository, times(1)).save(any(ChallengeEntity.class));
+        assertEquals(EXPIRED, challengeEntity.getStatus());
+    }
+}


### PR DESCRIPTION
## 개요 (Summary)

<!-- 여기에 PR의 주요 변경 사항과 목적을 간단히 설명하세요 -->
- 챌린지 게시물 등록, 수정, 조회(상세조회, 리스트 조회), 삭제 구현
- token을 받고 challeng 서비스로 라우팅 후 security context를 확인하여 권한인증 진행
- DueDate, StartDate, User 등에 따른 게시물 등록 및 수정 검증 진행


## 변경 사항 (Changes)

<!-- 변경된 파일 및 주요 변경 사항을 기술하세요 -->
- ChallengeController: api 컨트롤러 생성(생성, 전체 수정, 챌린지 취소, 상세조회, 리스트 조회, 삭제)
- ChallengeService: 챌린지 게시물 등록, 수정, 조회, 삭제 비즈니스 로직 구현
- ChallengeRepository: 챌린지 게시물 데이터 리포지토리 
- ChallengeFormValidator: 챌린지 생성 및 수정 Form의 유효성 검증 로직 구현
- ChangeChallengeForm: challenge 등록 및 수정 요청 DTO 인터페이스(구현체: CreateChallengeForm, UpdateChallengeForm)
- ChallengeResponseDto: 챌린지 상세 정보, 단순 정보를 저장하는 DTO
- MemberFeignClient: user 서비스 호출을 위한 open feign client 

## 테스트 결과 (Test Results)

<!-- 테스트 결과를 설명하세요 -->
- 챌린지 CRUD: 성공
- 챌린지 등록 및 수정 유효성 에러 핸들링: 성공
  - 챌린지 기간이 1개월 미만일 때
  - 아직 진행 중인 챌린지가 있을 때
  - 진행 중인 챌린지의 마감 기한을 앞당겼을 때
  - 이미 진행 중이라면 시작 날짜 변경 불가
  - 사용자의 id와 form 또는 entity의 userId가 일치하지 않을 때

## 체크리스트 (Checklist)

<!-- PR이 준비되었는지 확인하기 위한 체크리스트 -->
- [ v ] 코드가 의도한 대로 작동함
- [ v ] 새로운 테스트가 추가되었고, 기존 테스트가 통과함
- [ v ] 변경 사항이 적절하게 설명됨

## 리뷰 요청 사항 (Review Requests)

<!-- 리뷰어에게 검토를 요청하고 싶은 특정 사항이 있다면 여기에 작성하세요 -->
- 챌린지를 등록할 때 매개변수로 입력하는 form(CreateChallengeForm과 UpdateChallengeForm)의 내용에 대한 유효성을 검증하는 로직이 많아 validator 클래스를 만들어 유효성 검증을 진행했습니다. 하지만 코드 전반의 가독성이 다소 좋지 않은 것 같아 조언을 구하고 싶습니다. 
- challenge 서비스에 jwt 필터 클래스와 SecurityConfig 클래스를 만들어 토큰 필터링을 진행하였습니다. 이렇게 진행 할 시 각 서비스 별로 독립성이 보장되는 장점이 있고 서비스 내에서 api의 권한을 조정해야 할 때 보다 용이할 거라 생각했습니다. 하지만 서비스 끼리 호출할 때에도 항상 인증을 진행하게 되어 네트워크 과정에서 인증을 중복적으로 하게 됨으로써 성능 면에서 약점이 생기지는 않을지 실무에서는 보통 어떤 방식을 사용하는지 궁금합니다.

